### PR TITLE
Use ANF names in LLVM codegen

### DIFF
--- a/examples/data.ll
+++ b/examples/data.ll
@@ -17,44 +17,47 @@ entry:
   store i64* %2, i64** %3
   %4 = alloca i8
   store i8 1, i8* %4
-  %y = load i8, i8* %4
-  %5 = alloca %MySum*
-  store %MySum* %x, %MySum** %5
-  %c46 = load %MySum*, %MySum** %5
-  %6 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %7 = load i8, i8* %6
-  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %9 = load i64*, i64** %8
-  switch i8 %7, label %case.0.ret [
+  %y52 = load i8, i8* %4
+  %5 = alloca i8
+  store i8 %y52, i8* %5
+  %y = load i8, i8* %5
+  %6 = alloca %MySum*
+  store %MySum* %x, %MySum** %6
+  %c46 = load %MySum*, %MySum** %6
+  %7 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %8 = load i8, i8* %7
+  %9 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %10 = load i64*, i64** %9
+  switch i8 %8, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
     i8 2, label %case.2.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u47 = load i64, i64* %9
-  %10 = alloca i64
-  store i64 0, i64* %10
-  %11 = load i64, i64* %10
+  %_u47 = load i64, i64* %10
+  %11 = alloca i64
+  store i64 0, i64* %11
+  %12 = load i64, i64* %11
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %12 = bitcast i64* %9 to double*
-  %_u48 = load double, double* %12
-  %13 = call i64 @f(double %_u48, i8 %y)
-  %14 = alloca i64
-  store i64 %13, i64* %14
-  %15 = load i64, i64* %14
+  %13 = bitcast i64* %10 to double*
+  %_u48 = load double, double* %13
+  %14 = call i64 @f(double %_u48, i8 %y)
+  %15 = alloca i64
+  store i64 %14, i64* %15
+  %16 = load i64, i64* %15
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %16 = alloca i64
-  store i64 1, i64* %16
-  %17 = load i64, i64* %16
+  %17 = alloca i64
+  store i64 1, i64* %17
+  %18 = load i64, i64* %17
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ 0, %case.0.ret ], [ %13, %case.1.ret ], [ 1, %case.2.ret ]
+  %ret = phi i64 [ 0, %case.0.ret ], [ %14, %case.1.ret ], [ 1, %case.2.ret ]
   ret i64 %ret
 }
 

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -45,15 +45,12 @@ case.1.ret:                                       ; preds = %entry
   %13 = bitcast i64* %10 to double*
   %_u48 = load double, double* %13
   %14 = call i64 @f(double %_u48, i8 %y)
-  %15 = alloca i64
-  store i64 %14, i64* %15
-  %16 = load i64, i64* %15
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %17 = alloca i64
-  store i64 1, i64* %17
-  %18 = load i64, i64* %17
+  %15 = alloca i64
+  store i64 1, i64* %15
+  %16 = load i64, i64* %15
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -17,41 +17,38 @@ entry:
   store i64* %2, i64** %3
   %4 = alloca i8
   store i8 1, i8* %4
-  %y52 = load i8, i8* %4
-  %5 = alloca i8
-  store i8 %y52, i8* %5
-  %y = load i8, i8* %5
-  %6 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %7 = load i8, i8* %6
-  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %9 = load i64*, i64** %8
-  switch i8 %7, label %case.0.ret [
+  %y = load i8, i8* %4
+  %5 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %6 = load i8, i8* %5
+  %7 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %8 = load i64*, i64** %7
+  switch i8 %6, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
     i8 2, label %case.2.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u47 = load i64, i64* %9
-  %10 = alloca i64
-  store i64 0, i64* %10
-  %11 = load i64, i64* %10
+  %_u47 = load i64, i64* %8
+  %9 = alloca i64
+  store i64 0, i64* %9
+  %10 = load i64, i64* %9
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %12 = bitcast i64* %9 to double*
-  %_u48 = load double, double* %12
-  %13 = call i64 @f(double %_u48, i8 %y)
+  %11 = bitcast i64* %8 to double*
+  %_u48 = load double, double* %11
+  %12 = call i64 @f(double %_u48, i8 %y)
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %14 = alloca i64
-  store i64 1, i64* %14
-  %15 = load i64, i64* %14
+  %13 = alloca i64
+  store i64 1, i64* %13
+  %14 = load i64, i64* %13
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %11, %case.0.ret ], [ %13, %case.1.ret ], [ %15, %case.2.ret ]
+  %ret = phi i64 [ %10, %case.0.ret ], [ %12, %case.1.ret ], [ %14, %case.2.ret ]
   ret i64 %ret
 }
 

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -7,55 +7,55 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %0 = alloca %MySum
-  %1 = getelementptr %MySum, %MySum* %0, i32 0, i32 0
-  store i8 1, i8* %1
-  %2 = alloca double
-  store double 0x401F333333333333, double* %2
-  %3 = bitcast double* %2 to i64*
-  %4 = getelementptr %MySum, %MySum* %0, i32 0, i32 1
-  store i64* %3, i64** %4
+  %x = alloca %MySum
+  %0 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  store i8 1, i8* %0
+  %1 = alloca double
+  store double 0x401F333333333333, double* %1
+  %2 = bitcast double* %1 to i64*
+  %3 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  store i64* %2, i64** %3
+  %4 = alloca i8
+  store i8 1, i8* %4
+  %y = load i8, i8* %4
   %5 = alloca %MySum*
-  store %MySum* %0, %MySum** %5
-  %x = load %MySum*, %MySum** %5
-  %6 = alloca i8
-  store i8 1, i8* %6
-  %y = load i8, i8* %6
-  %7 = alloca %MySum*
-  store %MySum* %x, %MySum** %7
-  %c46 = load %MySum*, %MySum** %7
-  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %9 = load i8, i8* %8
-  %10 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %11 = load i64*, i64** %10
-  switch i8 %9, label %case.0.7 [
-    i8 0, label %case.0.7
-    i8 1, label %case.1.7
-    i8 2, label %case.2.7
+  store %MySum* %x, %MySum** %5
+  %c46 = load %MySum*, %MySum** %5
+  %6 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %7 = load i8, i8* %6
+  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %9 = load i64*, i64** %8
+  switch i8 %7, label %case.0.ret [
+    i8 0, label %case.0.ret
+    i8 1, label %case.1.ret
+    i8 2, label %case.2.ret
   ]
 
-case.0.7:                                         ; preds = %entry, %entry
-  %12 = load i64, i64* %11
-  %13 = alloca i64
-  store i64 %12, i64* %13
-  %_u47 = load i64, i64* %13
-  br label %case.end.7
+case.0.ret:                                       ; preds = %entry, %entry
+  %_u47 = load i64, i64* %9
+  %10 = alloca i64
+  store i64 0, i64* %10
+  %11 = load i64, i64* %10
+  br label %case.end.ret
 
-case.1.7:                                         ; preds = %entry
-  %14 = bitcast i64* %11 to double*
-  %15 = load double, double* %14
-  %16 = alloca double
-  store double %15, double* %16
-  %_u48 = load double, double* %16
-  %17 = call i64 @f(double %_u48, i8 %y)
-  br label %case.end.7
+case.1.ret:                                       ; preds = %entry
+  %12 = bitcast i64* %9 to double*
+  %_u48 = load double, double* %12
+  %13 = call i64 @f(double %_u48, i8 %y)
+  %14 = alloca i64
+  store i64 %13, i64* %14
+  %15 = load i64, i64* %14
+  br label %case.end.ret
 
-case.2.7:                                         ; preds = %entry
-  br label %case.end.7
+case.2.ret:                                       ; preds = %entry
+  %16 = alloca i64
+  store i64 1, i64* %16
+  %17 = load i64, i64* %16
+  br label %case.end.ret
 
-case.end.7:                                       ; preds = %case.2.7, %case.1.7, %case.0.7
-  %end.7 = phi i64 [ 0, %case.0.7 ], [ %17, %case.1.7 ], [ 1, %case.2.7 ]
-  ret i64 %end.7
+case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
+  %ret = phi i64 [ 0, %case.0.ret ], [ %13, %case.1.ret ], [ 1, %case.2.ret ]
+  ret i64 %ret
 }
 
 define private i64 @f(double %x, i8 %enum) {
@@ -63,24 +63,30 @@ entry:
   %0 = alloca i8
   store i8 %enum, i8* %0
   %c49 = load i8, i8* %0
-  switch i8 %enum, label %case.0.0 [
-    i8 0, label %case.0.0
-    i8 1, label %case.1.0
-    i8 2, label %case.2.0
+  switch i8 %enum, label %case.0.ret [
+    i8 0, label %case.0.ret
+    i8 1, label %case.1.ret
+    i8 2, label %case.2.ret
   ]
 
-case.0.0:                                         ; preds = %entry, %entry
-  br label %case.end.0
+case.0.ret:                                       ; preds = %entry, %entry
+  %1 = alloca i64
+  store i64 2, i64* %1
+  %2 = load i64, i64* %1
+  br label %case.end.ret
 
-case.1.0:                                         ; preds = %entry
-  %1 = fptoui double %x to i64
-  br label %case.end.0
+case.1.ret:                                       ; preds = %entry
+  %3 = fptoui double %x to i64
+  br label %case.end.ret
 
-case.2.0:                                         ; preds = %entry
-  br label %case.end.0
+case.2.ret:                                       ; preds = %entry
+  %4 = alloca i64
+  store i64 3, i64* %4
+  %5 = load i64, i64* %4
+  br label %case.end.ret
 
-case.end.0:                                       ; preds = %case.2.0, %case.1.0, %case.0.0
-  %end.0 = phi i64 [ 2, %case.0.0 ], [ %1, %case.1.0 ], [ 3, %case.2.0 ]
-  ret i64 %end.0
+case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
+  %ret = phi i64 [ 2, %case.0.ret ], [ %3, %case.1.ret ], [ 3, %case.2.ret ]
+  ret i64 %ret
 }
 

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -54,7 +54,7 @@ case.2.ret:                                       ; preds = %entry
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ 0, %case.0.ret ], [ %14, %case.1.ret ], [ 1, %case.2.ret ]
+  %ret = phi i64 [ %12, %case.0.ret ], [ %14, %case.1.ret ], [ %16, %case.2.ret ]
   ret i64 %ret
 }
 
@@ -86,7 +86,7 @@ case.2.ret:                                       ; preds = %entry
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ 2, %case.0.ret ], [ %3, %case.1.ret ], [ 3, %case.2.ret ]
+  %ret = phi i64 [ %2, %case.0.ret ], [ %3, %case.1.ret ], [ %5, %case.2.ret ]
   ret i64 %ret
 }
 

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -15,36 +15,54 @@ entry:
   %3 = bitcast double* %2 to i64*
   %4 = getelementptr %MySum, %MySum* %0, i32 0, i32 1
   store i64* %3, i64** %4
-  %5 = getelementptr %MySum, %MySum* %0, i32 0, i32 0
-  %6 = load i8, i8* %5
-  %7 = getelementptr %MySum, %MySum* %0, i32 0, i32 1
-  %8 = load i64*, i64** %7
-  switch i8 %6, label %case.0.5 [
-    i8 0, label %case.0.5
-    i8 1, label %case.1.5
-    i8 2, label %case.2.5
+  %5 = alloca %MySum*
+  store %MySum* %0, %MySum** %5
+  %x = load %MySum*, %MySum** %5
+  %6 = alloca i8
+  store i8 1, i8* %6
+  %y = load i8, i8* %6
+  %7 = alloca %MySum*
+  store %MySum* %x, %MySum** %7
+  %c46 = load %MySum*, %MySum** %7
+  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %9 = load i8, i8* %8
+  %10 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %11 = load i64*, i64** %10
+  switch i8 %9, label %case.0.7 [
+    i8 0, label %case.0.7
+    i8 1, label %case.1.7
+    i8 2, label %case.2.7
   ]
 
-case.0.5:                                         ; preds = %entry, %entry
-  %9 = load i64, i64* %8
-  br label %case.end.5
+case.0.7:                                         ; preds = %entry, %entry
+  %12 = load i64, i64* %11
+  %13 = alloca i64
+  store i64 %12, i64* %13
+  %_u47 = load i64, i64* %13
+  br label %case.end.7
 
-case.1.5:                                         ; preds = %entry
-  %10 = bitcast i64* %8 to double*
-  %11 = load double, double* %10
-  %12 = call i64 @f(double %11, i8 1)
-  br label %case.end.5
+case.1.7:                                         ; preds = %entry
+  %14 = bitcast i64* %11 to double*
+  %15 = load double, double* %14
+  %16 = alloca double
+  store double %15, double* %16
+  %_u48 = load double, double* %16
+  %17 = call i64 @f(double %_u48, i8 %y)
+  br label %case.end.7
 
-case.2.5:                                         ; preds = %entry
-  br label %case.end.5
+case.2.7:                                         ; preds = %entry
+  br label %case.end.7
 
-case.end.5:                                       ; preds = %case.2.5, %case.1.5, %case.0.5
-  %end.5 = phi i64 [ 0, %case.0.5 ], [ %12, %case.1.5 ], [ 1, %case.2.5 ]
-  ret i64 %end.5
+case.end.7:                                       ; preds = %case.2.7, %case.1.7, %case.0.7
+  %end.7 = phi i64 [ 0, %case.0.7 ], [ %17, %case.1.7 ], [ 1, %case.2.7 ]
+  ret i64 %end.7
 }
 
 define private i64 @f(double %x, i8 %enum) {
 entry:
+  %0 = alloca i8
+  store i8 %enum, i8* %0
+  %c49 = load i8, i8* %0
   switch i8 %enum, label %case.0.0 [
     i8 0, label %case.0.0
     i8 1, label %case.1.0
@@ -55,14 +73,14 @@ case.0.0:                                         ; preds = %entry, %entry
   br label %case.end.0
 
 case.1.0:                                         ; preds = %entry
-  %0 = fptoui double %x to i64
+  %1 = fptoui double %x to i64
   br label %case.end.0
 
 case.2.0:                                         ; preds = %entry
   br label %case.end.0
 
 case.end.0:                                       ; preds = %case.2.0, %case.1.0, %case.0.0
-  %end.0 = phi i64 [ 2, %case.0.0 ], [ %0, %case.1.0 ], [ 3, %case.2.0 ]
+  %end.0 = phi i64 [ 2, %case.0.0 ], [ %1, %case.1.0 ], [ 3, %case.2.0 ]
   ret i64 %end.0
 }
 

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -21,48 +21,42 @@ entry:
   %5 = alloca i8
   store i8 %y52, i8* %5
   %y = load i8, i8* %5
-  %6 = alloca %MySum*
-  store %MySum* %x, %MySum** %6
-  %c46 = load %MySum*, %MySum** %6
-  %7 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %8 = load i8, i8* %7
-  %9 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %10 = load i64*, i64** %9
-  switch i8 %8, label %case.0.ret [
+  %6 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %7 = load i8, i8* %6
+  %8 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %9 = load i64*, i64** %8
+  switch i8 %7, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
     i8 2, label %case.2.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u47 = load i64, i64* %10
-  %11 = alloca i64
-  store i64 0, i64* %11
-  %12 = load i64, i64* %11
+  %_u47 = load i64, i64* %9
+  %10 = alloca i64
+  store i64 0, i64* %10
+  %11 = load i64, i64* %10
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %13 = bitcast i64* %10 to double*
-  %_u48 = load double, double* %13
-  %14 = call i64 @f(double %_u48, i8 %y)
+  %12 = bitcast i64* %9 to double*
+  %_u48 = load double, double* %12
+  %13 = call i64 @f(double %_u48, i8 %y)
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %15 = alloca i64
-  store i64 1, i64* %15
-  %16 = load i64, i64* %15
+  %14 = alloca i64
+  store i64 1, i64* %14
+  %15 = load i64, i64* %14
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %12, %case.0.ret ], [ %14, %case.1.ret ], [ %16, %case.2.ret ]
+  %ret = phi i64 [ %11, %case.0.ret ], [ %13, %case.1.ret ], [ %15, %case.2.ret ]
   ret i64 %ret
 }
 
 define private i64 @f(double %x, i8 %enum) {
 entry:
-  %0 = alloca i8
-  store i8 %enum, i8* %0
-  %c49 = load i8, i8* %0
   switch i8 %enum, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
@@ -70,23 +64,23 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %1 = alloca i64
-  store i64 2, i64* %1
-  %2 = load i64, i64* %1
+  %0 = alloca i64
+  store i64 2, i64* %0
+  %1 = load i64, i64* %0
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %3 = fptoui double %x to i64
+  %2 = fptoui double %x to i64
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %4 = alloca i64
-  store i64 3, i64* %4
-  %5 = load i64, i64* %4
+  %3 = alloca i64
+  store i64 3, i64* %3
+  %4 = load i64, i64* %3
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %2, %case.0.ret ], [ %3, %case.1.ret ], [ %5, %case.2.ret ]
+  %ret = phi i64 [ %1, %case.0.ret ], [ %2, %case.1.ret ], [ %4, %case.2.ret ]
   ret i64 %ret
 }
 

--- a/examples/fib.amy
+++ b/examples/fib.amy
@@ -5,4 +5,4 @@ fib x =
   case x of
     0 -> 0
     1 -> 1
-    y -> iAdd# (fib (iSub# x 1)) (fib (iSub# x 2))
+    y -> iAdd# (fib (iSub# y 1)) (fib (iSub# y 2))

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -11,17 +11,32 @@ entry:
 
 define private i64 @fib(i64 %x) {
 entry:
+  %0 = alloca i64
+  store i64 %x, i64* %0
+  %c31 = load i64, i64* %0
   switch i64 %x, label %case.default.0 [
     i64 0, label %case.0.0
     i64 1, label %case.1.0
   ]
 
 case.default.0:                                   ; preds = %entry
-  %0 = sub i64 %x, 1
-  %1 = call i64 @fib(i64 %0)
-  %2 = sub i64 %x, 2
-  %3 = call i64 @fib(i64 %2)
-  %4 = add i64 %1, %3
+  %1 = sub i64 %x, 1
+  %2 = alloca i64
+  store i64 %1, i64* %2
+  %res34 = load i64, i64* %2
+  %3 = call i64 @fib(i64 %res34)
+  %4 = alloca i64
+  store i64 %3, i64* %4
+  %res35 = load i64, i64* %4
+  %5 = sub i64 %x, 2
+  %6 = alloca i64
+  store i64 %5, i64* %6
+  %res36 = load i64, i64* %6
+  %7 = call i64 @fib(i64 %res36)
+  %8 = alloca i64
+  store i64 %7, i64* %8
+  %res37 = load i64, i64* %8
+  %9 = add i64 %res35, %res37
   br label %case.end.0
 
 case.0.0:                                         ; preds = %entry
@@ -31,7 +46,7 @@ case.1.0:                                         ; preds = %entry
   br label %case.end.0
 
 case.end.0:                                       ; preds = %case.1.0, %case.0.0, %case.default.0
-  %end.0 = phi i64 [ %4, %case.default.0 ], [ 0, %case.0.0 ], [ 1, %case.1.0 ]
+  %end.0 = phi i64 [ %9, %case.default.0 ], [ 0, %case.0.0 ], [ 1, %case.1.0 ]
   ret i64 %end.0
 }
 

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -11,15 +11,15 @@ entry:
 
 define private i64 @fib(i64 %x) {
 entry:
-  %0 = alloca i64
-  store i64 %x, i64* %0
-  %c31 = load i64, i64* %0
   switch i64 %x, label %case.default.ret [
     i64 0, label %case.0.ret
     i64 1, label %case.1.ret
   ]
 
 case.default.ret:                                 ; preds = %entry
+  %0 = alloca i64
+  store i64 %x, i64* %0
+  %c31 = load i64, i64* %0
   %res34 = sub i64 %c31, 1
   %res35 = call i64 @fib(i64 %res34)
   %res36 = sub i64 %c31, 2

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -40,7 +40,7 @@ case.1.ret:                                       ; preds = %entry
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret, %case.default.ret
-  %ret = phi i64 [ %1, %case.default.ret ], [ 0, %case.0.ret ], [ 1, %case.1.ret ]
+  %ret = phi i64 [ %1, %case.default.ret ], [ %3, %case.0.ret ], [ %5, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -6,6 +6,9 @@ source_filename = "<string>"
 define i64 @main() {
 entry:
   %0 = call i64 @fib(i64 10)
+  %1 = alloca i64
+  store i64 %0, i64* %1
+  %ret = load i64, i64* %1
   ret i64 %0
 }
 
@@ -14,39 +17,39 @@ entry:
   %0 = alloca i64
   store i64 %x, i64* %0
   %c31 = load i64, i64* %0
-  switch i64 %x, label %case.default.0 [
-    i64 0, label %case.0.0
-    i64 1, label %case.1.0
+  switch i64 %x, label %case.default.ret [
+    i64 0, label %case.0.ret
+    i64 1, label %case.1.ret
   ]
 
-case.default.0:                                   ; preds = %entry
-  %1 = sub i64 %x, 1
+case.default.ret:                                 ; preds = %entry
+  %res34 = sub i64 %x, 1
+  %1 = call i64 @fib(i64 %res34)
   %2 = alloca i64
   store i64 %1, i64* %2
-  %res34 = load i64, i64* %2
-  %3 = call i64 @fib(i64 %res34)
+  %res35 = load i64, i64* %2
+  %res36 = sub i64 %x, 2
+  %3 = call i64 @fib(i64 %res36)
   %4 = alloca i64
   store i64 %3, i64* %4
-  %res35 = load i64, i64* %4
-  %5 = sub i64 %x, 2
+  %res37 = load i64, i64* %4
+  %5 = add i64 %res35, %res37
+  br label %case.end.ret
+
+case.0.ret:                                       ; preds = %entry
   %6 = alloca i64
-  store i64 %5, i64* %6
-  %res36 = load i64, i64* %6
-  %7 = call i64 @fib(i64 %res36)
+  store i64 0, i64* %6
+  %7 = load i64, i64* %6
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
   %8 = alloca i64
-  store i64 %7, i64* %8
-  %res37 = load i64, i64* %8
-  %9 = add i64 %res35, %res37
-  br label %case.end.0
+  store i64 1, i64* %8
+  %9 = load i64, i64* %8
+  br label %case.end.ret
 
-case.0.0:                                         ; preds = %entry
-  br label %case.end.0
-
-case.1.0:                                         ; preds = %entry
-  br label %case.end.0
-
-case.end.0:                                       ; preds = %case.1.0, %case.0.0, %case.default.0
-  %end.0 = phi i64 [ %9, %case.default.0 ], [ 0, %case.0.0 ], [ 1, %case.1.0 ]
-  ret i64 %end.0
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret, %case.default.ret
+  %ret = phi i64 [ %5, %case.default.ret ], [ 0, %case.0.ret ], [ 1, %case.1.ret ]
+  ret i64 %ret
 }
 

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -23,12 +23,12 @@ entry:
   ]
 
 case.default.ret:                                 ; preds = %entry
-  %res34 = sub i64 %x, 1
+  %res34 = sub i64 %c31, 1
   %1 = call i64 @fib(i64 %res34)
   %2 = alloca i64
   store i64 %1, i64* %2
   %res35 = load i64, i64* %2
-  %res36 = sub i64 %x, 2
+  %res36 = sub i64 %c31, 2
   %3 = call i64 @fib(i64 %res36)
   %4 = alloca i64
   store i64 %3, i64* %4

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -5,11 +5,8 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %0 = call i64 @fib(i64 10)
-  %1 = alloca i64
-  store i64 %0, i64* %1
-  %ret = load i64, i64* %1
-  ret i64 %0
+  %ret = call i64 @fib(i64 10)
+  ret i64 %ret
 }
 
 define private i64 @fib(i64 %x) {
@@ -24,32 +21,26 @@ entry:
 
 case.default.ret:                                 ; preds = %entry
   %res34 = sub i64 %c31, 1
-  %1 = call i64 @fib(i64 %res34)
-  %2 = alloca i64
-  store i64 %1, i64* %2
-  %res35 = load i64, i64* %2
+  %res35 = call i64 @fib(i64 %res34)
   %res36 = sub i64 %c31, 2
-  %3 = call i64 @fib(i64 %res36)
-  %4 = alloca i64
-  store i64 %3, i64* %4
-  %res37 = load i64, i64* %4
-  %5 = add i64 %res35, %res37
+  %res37 = call i64 @fib(i64 %res36)
+  %1 = add i64 %res35, %res37
   br label %case.end.ret
 
 case.0.ret:                                       ; preds = %entry
-  %6 = alloca i64
-  store i64 0, i64* %6
-  %7 = load i64, i64* %6
+  %2 = alloca i64
+  store i64 0, i64* %2
+  %3 = load i64, i64* %2
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %8 = alloca i64
-  store i64 1, i64* %8
-  %9 = load i64, i64* %8
+  %4 = alloca i64
+  store i64 1, i64* %4
+  %5 = load i64, i64* %4
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret, %case.default.ret
-  %ret = phi i64 [ %5, %case.default.ret ], [ 0, %case.0.ret ], [ 1, %case.1.ret ]
+  %ret = phi i64 [ %1, %case.default.ret ], [ 0, %case.0.ret ], [ 1, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/funcargs.ll
+++ b/examples/funcargs.ll
@@ -5,20 +5,14 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %0 = call i64 @apply(i64 (i64, i64)* @myAdd)
-  %1 = alloca i64
-  store i64 %0, i64* %1
-  %ret = load i64, i64* %1
-  ret i64 %0
+  %ret = call i64 @apply(i64 (i64, i64)* @myAdd)
+  ret i64 %ret
 }
 
 define private i64 @apply(i64 (i64, i64)* %f) {
 entry:
-  %0 = call i64 %f(i64 1, i64 2)
-  %1 = alloca i64
-  store i64 %0, i64* %1
-  %ret = load i64, i64* %1
-  ret i64 %0
+  %ret = call i64 %f(i64 1, i64 2)
+  ret i64 %ret
 }
 
 define private i64 @myAdd(i64 %x, i64 %y) {

--- a/examples/funcargs.ll
+++ b/examples/funcargs.ll
@@ -6,18 +6,24 @@ source_filename = "<string>"
 define i64 @main() {
 entry:
   %0 = call i64 @apply(i64 (i64, i64)* @myAdd)
+  %1 = alloca i64
+  store i64 %0, i64* %1
+  %ret = load i64, i64* %1
   ret i64 %0
 }
 
 define private i64 @apply(i64 (i64, i64)* %f) {
 entry:
   %0 = call i64 %f(i64 1, i64 2)
+  %1 = alloca i64
+  store i64 %0, i64* %1
+  %ret = load i64, i64* %1
   ret i64 %0
 }
 
 define private i64 @myAdd(i64 %x, i64 %y) {
 entry:
-  %0 = add i64 %x, %y
-  ret i64 %0
+  %ret = add i64 %x, %y
+  ret i64 %ret
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -7,57 +7,51 @@ declare i64 @abs(i64)
 
 define i64 @main() {
 entry:
-  %0 = alloca i1
-  store i1 true, i1* %0
-  %x37 = load i1, i1* %0
-  switch i1 %x37, label %case.0.x [
+  switch i1 true, label %case.0.x [
     i1 true, label %case.0.x
     i1 false, label %case.1.x
   ]
 
 case.0.x:                                         ; preds = %entry, %entry
-  %x38 = call i64 @f(i64 100)
-  %1 = call i64 @abs(i64 %x38)
+  %x37 = call i64 @f(i64 100)
+  %0 = call i64 @abs(i64 %x37)
   br label %case.end.x
 
 case.1.x:                                         ; preds = %entry
-  %x39 = call i64 @threeHundred()
-  %x40 = call i64 @f(i64 %x39)
-  %2 = call i64 @abs(i64 %x40)
+  %x38 = call i64 @threeHundred()
+  %x39 = call i64 @f(i64 %x38)
+  %1 = call i64 @abs(i64 %x39)
   br label %case.end.x
 
 case.end.x:                                       ; preds = %case.1.x, %case.0.x
-  %x = phi i64 [ %1, %case.0.x ], [ %2, %case.1.x ]
-  %3 = alloca i64
-  store i64 %x, i64* %3
-  %y = load i64, i64* %3
+  %x = phi i64 [ %0, %case.0.x ], [ %1, %case.1.x ]
+  %2 = alloca i64
+  store i64 %x, i64* %2
+  %y = load i64, i64* %2
   %ret = add i64 %x, %y
   ret i64 %ret
 }
 
 define private i64 @f(i64 %x) {
 entry:
-  %0 = alloca i1
-  store i1 true, i1* %0
-  %res41 = load i1, i1* %0
-  switch i1 %res41, label %case.0.ret [
+  switch i1 true, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %1 = call i64 @abs(i64 %x)
+  %0 = call i64 @abs(i64 %x)
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %res42 = call i64 @threeHundred()
-  %2 = alloca i64
-  store i64 %res42, i64* %2
-  %3 = load i64, i64* %2
+  %res40 = call i64 @threeHundred()
+  %1 = alloca i64
+  store i64 %res40, i64* %1
+  %2 = load i64, i64* %1
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %1, %case.0.ret ], [ %3, %case.1.ret ]
+  %ret = phi i64 [ %0, %case.0.ret ], [ %2, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -9,43 +9,46 @@ define i64 @main() {
 entry:
   %0 = alloca i1
   store i1 true, i1* %0
-  %c33 = load i1, i1* %0
-  switch i1 true, label %case.0.x [
+  %x37 = load i1, i1* %0
+  %1 = alloca i1
+  store i1 %x37, i1* %1
+  %c33 = load i1, i1* %1
+  switch i1 %x37, label %case.0.x [
     i1 true, label %case.0.x
     i1 false, label %case.1.x
   ]
 
 case.0.x:                                         ; preds = %entry, %entry
-  %1 = call i64 @f(i64 100)
-  %2 = alloca i64
-  store i64 %1, i64* %2
-  %x37 = load i64, i64* %2
-  %3 = call i64 @abs(i64 %x37)
-  %4 = alloca i64
-  store i64 %3, i64* %4
-  %5 = load i64, i64* %4
+  %2 = call i64 @f(i64 100)
+  %3 = alloca i64
+  store i64 %2, i64* %3
+  %x38 = load i64, i64* %3
+  %4 = call i64 @abs(i64 %x38)
+  %5 = alloca i64
+  store i64 %4, i64* %5
+  %6 = load i64, i64* %5
   br label %case.end.x
 
 case.1.x:                                         ; preds = %entry
-  %6 = call i64 @threeHundred()
-  %7 = alloca i64
-  store i64 %6, i64* %7
-  %x38 = load i64, i64* %7
-  %8 = call i64 @f(i64 %x38)
-  %9 = alloca i64
-  store i64 %8, i64* %9
-  %x39 = load i64, i64* %9
-  %10 = call i64 @abs(i64 %x39)
-  %11 = alloca i64
-  store i64 %10, i64* %11
-  %12 = load i64, i64* %11
+  %7 = call i64 @threeHundred()
+  %8 = alloca i64
+  store i64 %7, i64* %8
+  %x39 = load i64, i64* %8
+  %9 = call i64 @f(i64 %x39)
+  %10 = alloca i64
+  store i64 %9, i64* %10
+  %x40 = load i64, i64* %10
+  %11 = call i64 @abs(i64 %x40)
+  %12 = alloca i64
+  store i64 %11, i64* %12
+  %13 = load i64, i64* %12
   br label %case.end.x
 
 case.end.x:                                       ; preds = %case.1.x, %case.0.x
-  %x = phi i64 [ %3, %case.0.x ], [ %10, %case.1.x ]
-  %13 = alloca i64
-  store i64 %x, i64* %13
-  %y = load i64, i64* %13
+  %x = phi i64 [ %4, %case.0.x ], [ %11, %case.1.x ]
+  %14 = alloca i64
+  store i64 %x, i64* %14
+  %y = load i64, i64* %14
   %ret = add i64 %x, %y
   ret i64 %ret
 }
@@ -54,31 +57,34 @@ define private i64 @f(i64 %x) {
 entry:
   %0 = alloca i1
   store i1 true, i1* %0
-  %c34 = load i1, i1* %0
-  switch i1 true, label %case.0.ret [
+  %res41 = load i1, i1* %0
+  %1 = alloca i1
+  store i1 %res41, i1* %1
+  %c34 = load i1, i1* %1
+  switch i1 %res41, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %1 = call i64 @abs(i64 %x)
-  %2 = alloca i64
-  store i64 %1, i64* %2
-  %3 = load i64, i64* %2
+  %2 = call i64 @abs(i64 %x)
+  %3 = alloca i64
+  store i64 %2, i64* %3
+  %4 = load i64, i64* %3
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %4 = call i64 @threeHundred()
-  %5 = alloca i64
-  store i64 %4, i64* %5
-  %res40 = load i64, i64* %5
+  %5 = call i64 @threeHundred()
   %6 = alloca i64
-  store i64 %res40, i64* %6
-  %7 = load i64, i64* %6
+  store i64 %5, i64* %6
+  %res42 = load i64, i64* %6
+  %7 = alloca i64
+  store i64 %res42, i64* %7
+  %8 = load i64, i64* %7
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %1, %case.0.ret ], [ %res40, %case.1.ret ]
+  %ret = phi i64 [ %2, %case.0.ret ], [ %res42, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -10,9 +10,6 @@ entry:
   %0 = alloca i1
   store i1 true, i1* %0
   %x37 = load i1, i1* %0
-  %1 = alloca i1
-  store i1 %x37, i1* %1
-  %c33 = load i1, i1* %1
   switch i1 %x37, label %case.0.x [
     i1 true, label %case.0.x
     i1 false, label %case.1.x
@@ -20,20 +17,20 @@ entry:
 
 case.0.x:                                         ; preds = %entry, %entry
   %x38 = call i64 @f(i64 100)
-  %2 = call i64 @abs(i64 %x38)
+  %1 = call i64 @abs(i64 %x38)
   br label %case.end.x
 
 case.1.x:                                         ; preds = %entry
   %x39 = call i64 @threeHundred()
   %x40 = call i64 @f(i64 %x39)
-  %3 = call i64 @abs(i64 %x40)
+  %2 = call i64 @abs(i64 %x40)
   br label %case.end.x
 
 case.end.x:                                       ; preds = %case.1.x, %case.0.x
-  %x = phi i64 [ %2, %case.0.x ], [ %3, %case.1.x ]
-  %4 = alloca i64
-  store i64 %x, i64* %4
-  %y = load i64, i64* %4
+  %x = phi i64 [ %1, %case.0.x ], [ %2, %case.1.x ]
+  %3 = alloca i64
+  store i64 %x, i64* %3
+  %y = load i64, i64* %3
   %ret = add i64 %x, %y
   ret i64 %ret
 }
@@ -43,27 +40,24 @@ entry:
   %0 = alloca i1
   store i1 true, i1* %0
   %res41 = load i1, i1* %0
-  %1 = alloca i1
-  store i1 %res41, i1* %1
-  %c34 = load i1, i1* %1
   switch i1 %res41, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %2 = call i64 @abs(i64 %x)
+  %1 = call i64 @abs(i64 %x)
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
   %res42 = call i64 @threeHundred()
-  %3 = alloca i64
-  store i64 %res42, i64* %3
-  %4 = load i64, i64* %3
+  %2 = alloca i64
+  store i64 %res42, i64* %2
+  %3 = load i64, i64* %2
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %2, %case.0.ret ], [ %4, %case.1.ret ]
+  %ret = phi i64 [ %1, %case.0.ret ], [ %3, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -10,41 +10,44 @@ entry:
   %0 = alloca i1
   store i1 true, i1* %0
   %c33 = load i1, i1* %0
-  switch i1 true, label %case.0.0 [
-    i1 true, label %case.0.0
-    i1 false, label %case.1.0
+  switch i1 true, label %case.0.x [
+    i1 true, label %case.0.x
+    i1 false, label %case.1.x
   ]
 
-case.0.0:                                         ; preds = %entry, %entry
+case.0.x:                                         ; preds = %entry, %entry
   %1 = call i64 @f(i64 100)
   %2 = alloca i64
   store i64 %1, i64* %2
   %x37 = load i64, i64* %2
   %3 = call i64 @abs(i64 %x37)
-  br label %case.end.0
+  %4 = alloca i64
+  store i64 %3, i64* %4
+  %5 = load i64, i64* %4
+  br label %case.end.x
 
-case.1.0:                                         ; preds = %entry
-  %4 = call i64 @threeHundred()
-  %5 = alloca i64
-  store i64 %4, i64* %5
-  %x38 = load i64, i64* %5
-  %6 = call i64 @f(i64 %x38)
+case.1.x:                                         ; preds = %entry
+  %6 = call i64 @threeHundred()
   %7 = alloca i64
   store i64 %6, i64* %7
-  %x39 = load i64, i64* %7
-  %8 = call i64 @abs(i64 %x39)
-  br label %case.end.0
-
-case.end.0:                                       ; preds = %case.1.0, %case.0.0
-  %end.0 = phi i64 [ %3, %case.0.0 ], [ %8, %case.1.0 ]
+  %x38 = load i64, i64* %7
+  %8 = call i64 @f(i64 %x38)
   %9 = alloca i64
-  store i64 %end.0, i64* %9
-  %x = load i64, i64* %9
-  %10 = alloca i64
-  store i64 %x, i64* %10
-  %y = load i64, i64* %10
-  %11 = add i64 %x, %y
-  ret i64 %11
+  store i64 %8, i64* %9
+  %x39 = load i64, i64* %9
+  %10 = call i64 @abs(i64 %x39)
+  %11 = alloca i64
+  store i64 %10, i64* %11
+  %12 = load i64, i64* %11
+  br label %case.end.x
+
+case.end.x:                                       ; preds = %case.1.x, %case.0.x
+  %x = phi i64 [ %3, %case.0.x ], [ %10, %case.1.x ]
+  %13 = alloca i64
+  store i64 %x, i64* %13
+  %y = load i64, i64* %13
+  %ret = add i64 %x, %y
+  ret i64 %ret
 }
 
 define private i64 @f(i64 %x) {
@@ -52,29 +55,38 @@ entry:
   %0 = alloca i1
   store i1 true, i1* %0
   %c34 = load i1, i1* %0
-  switch i1 true, label %case.0.0 [
-    i1 true, label %case.0.0
-    i1 false, label %case.1.0
+  switch i1 true, label %case.0.ret [
+    i1 true, label %case.0.ret
+    i1 false, label %case.1.ret
   ]
 
-case.0.0:                                         ; preds = %entry, %entry
+case.0.ret:                                       ; preds = %entry, %entry
   %1 = call i64 @abs(i64 %x)
-  br label %case.end.0
+  %2 = alloca i64
+  store i64 %1, i64* %2
+  %3 = load i64, i64* %2
+  br label %case.end.ret
 
-case.1.0:                                         ; preds = %entry
-  %2 = call i64 @threeHundred()
-  %3 = alloca i64
-  store i64 %2, i64* %3
-  %res40 = load i64, i64* %3
-  br label %case.end.0
+case.1.ret:                                       ; preds = %entry
+  %4 = call i64 @threeHundred()
+  %5 = alloca i64
+  store i64 %4, i64* %5
+  %res40 = load i64, i64* %5
+  %6 = alloca i64
+  store i64 %res40, i64* %6
+  %7 = load i64, i64* %6
+  br label %case.end.ret
 
-case.end.0:                                       ; preds = %case.1.0, %case.0.0
-  %end.0 = phi i64 [ %1, %case.0.0 ], [ %res40, %case.1.0 ]
-  ret i64 %end.0
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi i64 [ %1, %case.0.ret ], [ %res40, %case.1.ret ]
+  ret i64 %ret
 }
 
 define private i64 @threeHundred() {
 entry:
+  %0 = alloca i64
+  store i64 300, i64* %0
+  %ret = load i64, i64* %0
   ret i64 300
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -19,36 +19,21 @@ entry:
   ]
 
 case.0.x:                                         ; preds = %entry, %entry
-  %2 = call i64 @f(i64 100)
-  %3 = alloca i64
-  store i64 %2, i64* %3
-  %x38 = load i64, i64* %3
-  %4 = call i64 @abs(i64 %x38)
-  %5 = alloca i64
-  store i64 %4, i64* %5
-  %6 = load i64, i64* %5
+  %x38 = call i64 @f(i64 100)
+  %2 = call i64 @abs(i64 %x38)
   br label %case.end.x
 
 case.1.x:                                         ; preds = %entry
-  %7 = call i64 @threeHundred()
-  %8 = alloca i64
-  store i64 %7, i64* %8
-  %x39 = load i64, i64* %8
-  %9 = call i64 @f(i64 %x39)
-  %10 = alloca i64
-  store i64 %9, i64* %10
-  %x40 = load i64, i64* %10
-  %11 = call i64 @abs(i64 %x40)
-  %12 = alloca i64
-  store i64 %11, i64* %12
-  %13 = load i64, i64* %12
+  %x39 = call i64 @threeHundred()
+  %x40 = call i64 @f(i64 %x39)
+  %3 = call i64 @abs(i64 %x40)
   br label %case.end.x
 
 case.end.x:                                       ; preds = %case.1.x, %case.0.x
-  %x = phi i64 [ %4, %case.0.x ], [ %11, %case.1.x ]
-  %14 = alloca i64
-  store i64 %x, i64* %14
-  %y = load i64, i64* %14
+  %x = phi i64 [ %2, %case.0.x ], [ %3, %case.1.x ]
+  %4 = alloca i64
+  store i64 %x, i64* %4
+  %y = load i64, i64* %4
   %ret = add i64 %x, %y
   ret i64 %ret
 }
@@ -68,19 +53,13 @@ entry:
 
 case.0.ret:                                       ; preds = %entry, %entry
   %2 = call i64 @abs(i64 %x)
-  %3 = alloca i64
-  store i64 %2, i64* %3
-  %4 = load i64, i64* %3
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %5 = call i64 @threeHundred()
-  %6 = alloca i64
-  store i64 %5, i64* %6
-  %res42 = load i64, i64* %6
-  %7 = alloca i64
-  store i64 %res42, i64* %7
-  %8 = load i64, i64* %7
+  %res42 = call i64 @threeHundred()
+  %3 = alloca i64
+  store i64 %res42, i64* %3
+  %4 = load i64, i64* %3
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -7,45 +7,69 @@ declare i64 @abs(i64)
 
 define i64 @main() {
 entry:
+  %0 = alloca i1
+  store i1 true, i1* %0
+  %c33 = load i1, i1* %0
   switch i1 true, label %case.0.0 [
     i1 true, label %case.0.0
     i1 false, label %case.1.0
   ]
 
 case.0.0:                                         ; preds = %entry, %entry
-  %0 = call i64 @f(i64 100)
-  %1 = call i64 @abs(i64 %0)
+  %1 = call i64 @f(i64 100)
+  %2 = alloca i64
+  store i64 %1, i64* %2
+  %x37 = load i64, i64* %2
+  %3 = call i64 @abs(i64 %x37)
   br label %case.end.0
 
 case.1.0:                                         ; preds = %entry
-  %2 = call i64 @threeHundred()
-  %3 = call i64 @f(i64 %2)
-  %4 = call i64 @abs(i64 %3)
+  %4 = call i64 @threeHundred()
+  %5 = alloca i64
+  store i64 %4, i64* %5
+  %x38 = load i64, i64* %5
+  %6 = call i64 @f(i64 %x38)
+  %7 = alloca i64
+  store i64 %6, i64* %7
+  %x39 = load i64, i64* %7
+  %8 = call i64 @abs(i64 %x39)
   br label %case.end.0
 
 case.end.0:                                       ; preds = %case.1.0, %case.0.0
-  %end.0 = phi i64 [ %1, %case.0.0 ], [ %4, %case.1.0 ]
-  %5 = add i64 %end.0, %end.0
-  ret i64 %5
+  %end.0 = phi i64 [ %3, %case.0.0 ], [ %8, %case.1.0 ]
+  %9 = alloca i64
+  store i64 %end.0, i64* %9
+  %x = load i64, i64* %9
+  %10 = alloca i64
+  store i64 %x, i64* %10
+  %y = load i64, i64* %10
+  %11 = add i64 %x, %y
+  ret i64 %11
 }
 
 define private i64 @f(i64 %x) {
 entry:
+  %0 = alloca i1
+  store i1 true, i1* %0
+  %c34 = load i1, i1* %0
   switch i1 true, label %case.0.0 [
     i1 true, label %case.0.0
     i1 false, label %case.1.0
   ]
 
 case.0.0:                                         ; preds = %entry, %entry
-  %0 = call i64 @abs(i64 %x)
+  %1 = call i64 @abs(i64 %x)
   br label %case.end.0
 
 case.1.0:                                         ; preds = %entry
-  %1 = call i64 @threeHundred()
+  %2 = call i64 @threeHundred()
+  %3 = alloca i64
+  store i64 %2, i64* %3
+  %res40 = load i64, i64* %3
   br label %case.end.0
 
 case.end.0:                                       ; preds = %case.1.0, %case.0.0
-  %end.0 = phi i64 [ %0, %case.0.0 ], [ %1, %case.1.0 ]
+  %end.0 = phi i64 [ %1, %case.0.0 ], [ %res40, %case.1.0 ]
   ret i64 %end.0
 }
 

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -63,7 +63,7 @@ case.1.ret:                                       ; preds = %entry
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %2, %case.0.ret ], [ %res42, %case.1.ret ]
+  %ret = phi i64 [ %2, %case.0.ret ], [ %4, %case.1.ret ]
   ret i64 %ret
 }
 
@@ -72,6 +72,6 @@ entry:
   %0 = alloca i64
   store i64 300, i64* %0
   %ret = load i64, i64* %0
-  ret i64 300
+  ret i64 %ret
 }
 

--- a/examples/poly.ll
+++ b/examples/poly.ll
@@ -10,33 +10,33 @@ entry:
   %1 = bitcast double* %0 to i64*
   %2 = call i64* @id(i64* %1)
   %3 = bitcast i64* %2 to double*
-  %4 = load double, double* %3
-  %5 = alloca double
-  store double %4, double* %5
-  %res38 = load double, double* %5
+  %res38 = load double, double* %3
+  %4 = alloca double
+  store double %res38, double* %4
+  %5 = bitcast double* %4 to i64*
   %6 = alloca double
-  store double %res38, double* %6
+  store double 5.100000e+00, double* %6
   %7 = bitcast double* %6 to i64*
-  %8 = alloca double
-  store double 5.100000e+00, double* %8
-  %9 = bitcast double* %8 to i64*
-  %10 = call i64* @const(i64* %7, i64* %9)
-  %11 = bitcast i64* %10 to double*
-  %12 = load double, double* %11
-  %13 = alloca double
-  store double %12, double* %13
-  %res39 = load double, double* %13
-  %14 = fptoui double %res39 to i64
-  ret i64 %14
+  %8 = call i64* @const(i64* %5, i64* %7)
+  %9 = bitcast i64* %8 to double*
+  %res39 = load double, double* %9
+  %ret = fptoui double %res39 to i64
+  ret i64 %ret
 }
 
 define private i64* @id(i64* %x) {
 entry:
+  %0 = alloca i64*
+  store i64* %x, i64** %0
+  %ret = load i64*, i64** %0
   ret i64* %x
 }
 
 define private i64* @const(i64* %x, i64* %y) {
 entry:
+  %0 = alloca i64*
+  store i64* %x, i64** %0
+  %ret = load i64*, i64** %0
   ret i64* %x
 }
 

--- a/examples/poly.ll
+++ b/examples/poly.ll
@@ -13,15 +13,21 @@ entry:
   %4 = load double, double* %3
   %5 = alloca double
   store double %4, double* %5
-  %6 = bitcast double* %5 to i64*
-  %7 = alloca double
-  store double 5.100000e+00, double* %7
-  %8 = bitcast double* %7 to i64*
-  %9 = call i64* @const(i64* %6, i64* %8)
-  %10 = bitcast i64* %9 to double*
-  %11 = load double, double* %10
-  %12 = fptoui double %11 to i64
-  ret i64 %12
+  %res38 = load double, double* %5
+  %6 = alloca double
+  store double %res38, double* %6
+  %7 = bitcast double* %6 to i64*
+  %8 = alloca double
+  store double 5.100000e+00, double* %8
+  %9 = bitcast double* %8 to i64*
+  %10 = call i64* @const(i64* %7, i64* %9)
+  %11 = bitcast i64* %10 to double*
+  %12 = load double, double* %11
+  %13 = alloca double
+  store double %12, double* %13
+  %res39 = load double, double* %13
+  %14 = fptoui double %res39 to i64
+  ret i64 %14
 }
 
 define private i64* @id(i64* %x) {

--- a/examples/poly.ll
+++ b/examples/poly.ll
@@ -29,7 +29,7 @@ entry:
   %0 = alloca i64*
   store i64* %x, i64** %0
   %ret = load i64*, i64** %0
-  ret i64* %x
+  ret i64* %ret
 }
 
 define private i64* @const(i64* %x, i64* %y) {
@@ -37,6 +37,6 @@ entry:
   %0 = alloca i64*
   store i64* %x, i64** %0
   %ret = load i64*, i64** %0
-  ret i64* %x
+  ret i64* %ret
 }
 

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -18,28 +18,25 @@ entry:
   %y = add i64 %x, -1
   %res36 = sub i64 3, %y
   %res37 = icmp slt i64 5, %res36
-  %0 = alloca i1
-  store i1 %res37, i1* %0
-  %c31 = load i1, i1* %0
   switch i1 %res37, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %1 = alloca i64
-  store i64 100, i64* %1
-  %2 = load i64, i64* %1
+  %0 = alloca i64
+  store i64 100, i64* %0
+  %1 = load i64, i64* %0
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %3 = alloca i64
-  store i64 200, i64* %3
-  %4 = load i64, i64* %3
+  %2 = alloca i64
+  store i64 200, i64* %2
+  %3 = load i64, i64* %2
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %2, %case.0.ret ], [ %4, %case.1.ret ]
+  %ret = phi i64 [ %1, %case.0.ret ], [ %3, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -5,29 +5,50 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %0 = call i64 @f(i64 2)
-  %1 = call i64 @f(i64 %0)
-  ret i64 %1
+  %0 = alloca i64
+  store i64 2, i64* %0
+  %x = load i64, i64* %0
+  %1 = call i64 @f(i64 %x)
+  %2 = alloca i64
+  store i64 %1, i64* %2
+  %res34 = load i64, i64* %2
+  %3 = call i64 @f(i64 %res34)
+  ret i64 %3
 }
 
 define private i64 @f(i64 %x) {
 entry:
-  %0 = add i64 %x, -1
-  %1 = sub i64 3, %0
-  %2 = icmp slt i64 5, %1
-  switch i1 %2, label %case.0.4 [
-    i1 true, label %case.0.4
-    i1 false, label %case.1.4
+  %0 = alloca i64
+  store i64 -1, i64* %0
+  %y35 = load i64, i64* %0
+  %1 = add i64 %x, %y35
+  %2 = alloca i64
+  store i64 %1, i64* %2
+  %y = load i64, i64* %2
+  %3 = sub i64 3, %y
+  %4 = alloca i64
+  store i64 %3, i64* %4
+  %res36 = load i64, i64* %4
+  %5 = icmp slt i64 5, %res36
+  %6 = alloca i1
+  store i1 %5, i1* %6
+  %res37 = load i1, i1* %6
+  %7 = alloca i1
+  store i1 %res37, i1* %7
+  %c31 = load i1, i1* %7
+  switch i1 %res37, label %case.0.8 [
+    i1 true, label %case.0.8
+    i1 false, label %case.1.8
   ]
 
-case.0.4:                                         ; preds = %entry, %entry
-  br label %case.end.4
+case.0.8:                                         ; preds = %entry, %entry
+  br label %case.end.8
 
-case.1.4:                                         ; preds = %entry
-  br label %case.end.4
+case.1.8:                                         ; preds = %entry
+  br label %case.end.8
 
-case.end.4:                                       ; preds = %case.1.4, %case.0.4
-  %end.4 = phi i64 [ 100, %case.0.4 ], [ 200, %case.1.4 ]
-  ret i64 %end.4
+case.end.8:                                       ; preds = %case.1.8, %case.0.8
+  %end.8 = phi i64 [ 100, %case.0.8 ], [ 200, %case.1.8 ]
+  ret i64 %end.8
 }
 

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -8,15 +8,9 @@ entry:
   %0 = alloca i64
   store i64 2, i64* %0
   %x = load i64, i64* %0
-  %1 = call i64 @f(i64 %x)
-  %2 = alloca i64
-  store i64 %1, i64* %2
-  %res34 = load i64, i64* %2
-  %3 = call i64 @f(i64 %res34)
-  %4 = alloca i64
-  store i64 %3, i64* %4
-  %ret = load i64, i64* %4
-  ret i64 %3
+  %res34 = call i64 @f(i64 %x)
+  %ret = call i64 @f(i64 %res34)
+  ret i64 %ret
 }
 
 define private i64 @f(i64 %x) {

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -13,42 +13,39 @@ entry:
   store i64 %1, i64* %2
   %res34 = load i64, i64* %2
   %3 = call i64 @f(i64 %res34)
+  %4 = alloca i64
+  store i64 %3, i64* %4
+  %ret = load i64, i64* %4
   ret i64 %3
 }
 
 define private i64 @f(i64 %x) {
 entry:
-  %0 = alloca i64
-  store i64 -1, i64* %0
-  %y35 = load i64, i64* %0
-  %1 = add i64 %x, %y35
-  %2 = alloca i64
-  store i64 %1, i64* %2
-  %y = load i64, i64* %2
-  %3 = sub i64 3, %y
-  %4 = alloca i64
-  store i64 %3, i64* %4
-  %res36 = load i64, i64* %4
-  %5 = icmp slt i64 5, %res36
-  %6 = alloca i1
-  store i1 %5, i1* %6
-  %res37 = load i1, i1* %6
-  %7 = alloca i1
-  store i1 %res37, i1* %7
-  %c31 = load i1, i1* %7
-  switch i1 %res37, label %case.0.8 [
-    i1 true, label %case.0.8
-    i1 false, label %case.1.8
+  %y = add i64 %x, -1
+  %res36 = sub i64 3, %y
+  %res37 = icmp slt i64 5, %res36
+  %0 = alloca i1
+  store i1 %res37, i1* %0
+  %c31 = load i1, i1* %0
+  switch i1 %res37, label %case.0.ret [
+    i1 true, label %case.0.ret
+    i1 false, label %case.1.ret
   ]
 
-case.0.8:                                         ; preds = %entry, %entry
-  br label %case.end.8
+case.0.ret:                                       ; preds = %entry, %entry
+  %1 = alloca i64
+  store i64 100, i64* %1
+  %2 = load i64, i64* %1
+  br label %case.end.ret
 
-case.1.8:                                         ; preds = %entry
-  br label %case.end.8
+case.1.ret:                                       ; preds = %entry
+  %3 = alloca i64
+  store i64 200, i64* %3
+  %4 = load i64, i64* %3
+  br label %case.end.ret
 
-case.end.8:                                       ; preds = %case.1.8, %case.0.8
-  %end.8 = phi i64 [ 100, %case.0.8 ], [ 200, %case.1.8 ]
-  ret i64 %end.8
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi i64 [ 100, %case.0.ret ], [ 200, %case.1.ret ]
+  ret i64 %ret
 }
 

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -39,7 +39,7 @@ case.1.ret:                                       ; preds = %entry
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ 100, %case.0.ret ], [ 200, %case.1.ret ]
+  %ret = phi i64 [ %2, %case.0.ret ], [ %4, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/library/Amy/ANF/AST.hs
+++ b/library/Amy/ANF/AST.hs
@@ -16,6 +16,7 @@ module Amy.ANF.AST
   , Pattern(..)
   , PatCons(..)
   , App(..)
+  , ConApp(..)
 
   , Ident(..)
   , Type(..)
@@ -78,6 +79,7 @@ data DataConInfo
 data Val
   = Var !(Typed Ident)
   | Lit !Literal
+  | ConEnum !Word32 !DataConInfo
   deriving (Show, Eq)
 
 data Expr
@@ -85,7 +87,7 @@ data Expr
   | ELetVal !LetVal
   | ECase !Case
   | EApp !(App (Typed Ident))
-  | ECons !(App (Typed DataConInfo))
+  | EConApp !ConApp
   | EPrimOp !(App PrimitiveFunction)
   deriving (Show, Eq)
 
@@ -134,6 +136,14 @@ data App f
   { appFunction :: !f
   , appArgs :: ![Val]
   , appReturnType :: !Type
+  } deriving (Show, Eq)
+
+data ConApp
+  = ConApp
+  { conAppCon :: !DataConInfo
+  , conAppArg :: !(Maybe Val)
+  , conAppTaggedUnionName :: !Text
+  , conAppTaggedUnionTagBits :: !Word32
   } deriving (Show, Eq)
 
 -- | An identifier from source code

--- a/library/Amy/ANF/AST.hs
+++ b/library/Amy/ANF/AST.hs
@@ -8,7 +8,6 @@ module Amy.ANF.AST
   , DataConstructor(..)
   , DataConInfo(..)
   , Val(..)
-  , Var(..)
   , Expr(..)
   , LetVal(..)
   , LetValBinding(..)
@@ -77,13 +76,8 @@ data DataConInfo
   } deriving (Show, Eq)
 
 data Val
-  = Var !Var
+  = Var !(Typed Ident)
   | Lit !Literal
-  deriving (Show, Eq)
-
-data Var
-  = VVal !(Typed Ident)
-  | VCons !(Typed DataConInfo)
   deriving (Show, Eq)
 
 data Expr

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -170,12 +170,6 @@ normalizeName name expr c = do
   exprType <- convertType $ expressionType expr
   mkNormalizeLet name expr' exprType c
 
--- normalizeDataCon :: C.Typed C.DataConInfo -> ANF.Expr
--- normalizeDataCon (C.Typed ty info) = do
---   con' <- convertDataConInfo con
---   ty' <- convertType ty
---   mkNormalizeLet name (ANF.ECons $ ANF.App (ANF.Typed ty' con') [] ty') ty' c
-
 mkNormalizeLet :: Text -> ANF.Expr -> ANF.Type -> (ANF.Val -> ANFConvert ANF.Expr) -> ANFConvert ANF.Expr
 mkNormalizeLet name expr exprType c = do
   newIdent <- freshIdent name

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -43,12 +43,8 @@ prettyIdent :: Ident -> Doc ann
 prettyIdent (Ident name _ _) = pretty name
 
 prettyVal :: Val -> Doc ann
-prettyVal (Var var) = prettyVar var
+prettyVal (Var (Typed _ ident)) = prettyIdent ident
 prettyVal (Lit lit) = pretty $ showLiteral lit
-
-prettyVar :: Var -> Doc ann
-prettyVar (VVal (Typed _ var)) = prettyIdent var
-prettyVar (VCons (Typed _ cons)) = pretty . dataConstructorName . dataConInfoCons $ cons
 
 prettyExpr :: Expr -> Doc ann
 prettyExpr (EVal val) = prettyVal val
@@ -65,11 +61,12 @@ prettyExpr (ECase (Case scrutinee (Typed _ bind) matches mDefault _)) =
       Just def -> [("__DEFAULT", prettyExpr def)]
 prettyExpr (ELetVal (LetVal bindings body)) =
   prettyLetVal (prettyLetValBinding <$> bindings) (prettyExpr body)
-prettyExpr (EApp (App (Typed _ ident) args _)) = sep $ prettyIdent ident : (prettyVal <$> args)
+prettyExpr (EApp (App (Typed _ ident) args _)) =
+  "$call" <+> prettyIdent ident <+> list (prettyVal <$> args)
 prettyExpr (ECons (App (Typed _ info) args _)) =
-  sep $ pretty (dataConstructorName $ dataConInfoCons info) : (prettyVal <$> args)
+  "$mkCon" <+> pretty (dataConstructorName $ dataConInfoCons info) <+> list (prettyVal <$> args)
 prettyExpr (EPrimOp (App (PrimitiveFunction _ name _ _) args _)) =
-  sep $ pretty name : (prettyVal <$> args)
+  "$primOp" <+> pretty name <+> list (prettyVal <$> args)
 
 prettyLetValBinding :: LetValBinding -> Doc ann
 prettyLetValBinding (LetValBinding ident ty body) =

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -6,6 +6,7 @@ module Amy.ANF.Pretty
   ) where
 
 import Data.Foldable (toList)
+import Data.Maybe (maybeToList)
 
 import Amy.ANF.AST
 import Amy.Literal
@@ -45,6 +46,7 @@ prettyIdent (Ident name _ _) = pretty name
 prettyVal :: Val -> Doc ann
 prettyVal (Var (Typed _ ident)) = prettyIdent ident
 prettyVal (Lit lit) = pretty $ showLiteral lit
+prettyVal (ConEnum _ con) = pretty (dataConstructorName $ dataConInfoCons con)
 
 prettyExpr :: Expr -> Doc ann
 prettyExpr (EVal val) = prettyVal val
@@ -63,8 +65,8 @@ prettyExpr (ELetVal (LetVal bindings body)) =
   prettyLetVal (prettyLetValBinding <$> bindings) (prettyExpr body)
 prettyExpr (EApp (App (Typed _ ident) args _)) =
   "$call" <+> prettyIdent ident <+> list (prettyVal <$> args)
-prettyExpr (ECons (App (Typed _ info) args _)) =
-  "$mkCon" <+> pretty (dataConstructorName $ dataConInfoCons info) <+> list (prettyVal <$> args)
+prettyExpr (EConApp (ConApp info mArg _ _)) =
+  "$mkCon" <+> pretty (dataConstructorName $ dataConInfoCons info) <+> list (prettyVal <$> maybeToList mArg)
 prettyExpr (EPrimOp (App (PrimitiveFunction _ name _ _) args _)) =
   "$primOp" <+> pretty name <+> list (prettyVal <$> args)
 

--- a/library/Amy/Codegen/CaseBlocks.hs
+++ b/library/Amy/Codegen/CaseBlocks.hs
@@ -36,7 +36,6 @@ data CaseDefaultBlock
   { caseDefaultBlockExpr :: !Expr
   , caseDefaultBlockName :: !Name
   , caseDefaultBlockNextName :: !Name
-  , caseDefaultBlockIdent :: !(Typed Ident)
   } deriving (Show, Eq)
 
 data CaseEndBlock
@@ -47,7 +46,7 @@ data CaseEndBlock
   } deriving (Show, Eq)
 
 caseBlocks :: (String -> Name) -> Case -> CaseBlocks
-caseBlocks mkBlockName (Case _ bind matches mDefault ty) =
+caseBlocks mkBlockName (Case _ _ matches mDefault ty) =
   let
     -- Compute names for everything
     defaultBlockName = mkBlockName "case.default."
@@ -66,7 +65,6 @@ caseBlocks mkBlockName (Case _ bind matches mDefault ty) =
       { caseDefaultBlockExpr = expr
       , caseDefaultBlockName = defaultBlockName
       , caseDefaultBlockNextName = defaultBlockNextName
-      , caseDefaultBlockIdent = bind
       }
     defaultBlock = mkDefaultBlock <$> mDefault
     switchDefaultBlockName =

--- a/library/Amy/Codegen/CaseBlocks.hs
+++ b/library/Amy/Codegen/CaseBlocks.hs
@@ -41,7 +41,6 @@ data CaseDefaultBlock
 data CaseEndBlock
   = CaseEndBlock
   { caseEndBlockName :: !Name
-  , caseEndBlockOperandName :: !Name
   , caseEndBlockType :: !ANF.Type
   } deriving (Show, Eq)
 
@@ -51,7 +50,6 @@ caseBlocks mkBlockName (Case _ _ matches mDefault ty) =
     -- Compute names for everything
     defaultBlockName = mkBlockName "case.default."
     endBlockName = mkBlockName "case.end."
-    endOpName = mkBlockName "end."
     literalBlockNames = mkBlockName . (\i -> "case." ++ i ++ ".") . show <$> [0 .. (length matches - 1)]
     nextLiteralBlockNames = drop 1 literalBlockNames ++ [endBlockName]
 
@@ -94,7 +92,6 @@ caseBlocks mkBlockName (Case _ _ matches mDefault ty) =
     endBlock =
       CaseEndBlock
       { caseEndBlockName = endBlockName
-      , caseEndBlockOperandName = endOpName
       , caseEndBlockType = ty
       }
   in

--- a/library/Amy/Codegen/Pure.hs
+++ b/library/Amy/Codegen/Pure.hs
@@ -124,7 +124,6 @@ codegenExpr' name' (ANF.ECase case'@(ANF.Case scrutinee (Typed bindingTy binding
 
   -- Generate the switch statement
   scrutineeOp <- valOperand scrutinee
-  bindOpToName (identToName bindingIdent) scrutineeOp
 
   -- Extract tag from scrutinee op if we have to
   (switchOp, mArgOp) <-
@@ -146,7 +145,8 @@ codegenExpr' name' (ANF.ECase case'@(ANF.Case scrutinee (Typed bindingTy binding
       finalBlockName <- currentBlockName
       terminateBlock (Do $ Br endBlockName []) nextBlockName
       pure (LocalReference (operandType op) exprName, finalBlockName)
-    generateCaseDefaultBlock (CaseDefaultBlock expr _ nextBlockName) =
+    generateCaseDefaultBlock (CaseDefaultBlock expr _ nextBlockName) = do
+      bindOpToName (identToName bindingIdent) scrutineeOp
       generateBlockExpr expr nextBlockName
     generateCaseLiteralBlock (CaseLiteralBlock expr _ nextBlockName _ mBind) = do
       for_ mBind $ \(Typed ty ident) -> do

--- a/library/Amy/Codegen/Pure.hs
+++ b/library/Amy/Codegen/Pure.hs
@@ -126,6 +126,8 @@ codegenExpr' name' (ANF.ECase case'@(ANF.Case scrutinee (Typed bindingTy binding
   scrutineeOp <- valOperand scrutinee
 
   -- Extract tag from scrutinee op if we have to
+  -- TODO: Should we extract the argument once here or extract it in every
+  -- block that needs it? I feel like extracting it here is a bit funny.
   (switchOp, mArgOp) <-
     case bindingTy of
       TaggedUnionType _ bits -> unpackConstructor scrutineeOp bits

--- a/library/Amy/Codegen/Pure.hs
+++ b/library/Amy/Codegen/Pure.hs
@@ -105,6 +105,9 @@ codegenExpr expr = runBlockGen $ codegenExpr' (textToName "ret") expr
 
 codegenExpr' :: Name -> ANF.Expr -> BlockGen Operand
 codegenExpr' name' (ANF.EVal val) = do
+  -- If we get here that means the inliner probably didn't do its job very
+  -- well, and there is a primitive value being used as a top-level expression.
+  -- No worries, LLVM will most certainly remove these redundant instructions.
   op <- valOperand val
   bindOpToName name' op
   pure (LocalReference (operandType op) name')

--- a/library/Amy/Codegen/TypeConversion.hs
+++ b/library/Amy/Codegen/TypeConversion.hs
@@ -4,8 +4,10 @@ module Amy.Codegen.TypeConversion
   ( maybeConvertPointer
   , loadPointerToType
   , operandType
+  , bindOpToName
   ) where
 
+import Data.Foldable (for_)
 import LLVM.AST
 import LLVM.AST.AddrSpace
 import qualified LLVM.AST.Constant as C
@@ -13,15 +15,17 @@ import LLVM.AST.Float as F
 
 import Amy.Codegen.Monad
 
-maybeConvertPointer :: Operand -> Type -> BlockGen Operand
-maybeConvertPointer op targetTy =
+maybeConvertPointer :: Maybe Name -> Operand -> Type -> BlockGen Operand
+maybeConvertPointer mName op targetTy =
   if operandType op == targetTy
-  then pure op
+  then do
+    for_ mName $ \name' -> bindOpToName name' op
+    pure op
   else
     case (operandType op, targetTy) of
-      (PointerType _ _, PointerType _ _) -> maybeBitcast targetTy op
-      (_, PointerType _ _) -> allocOp op >>= maybeBitcast targetTy
-      (PointerType _ _, _) -> maybeBitcast (PointerType targetTy (AddrSpace 0)) op >>= loadPointerToType targetTy
+      (PointerType _ _, PointerType _ _) -> maybeBitcast mName targetTy op
+      (_, PointerType _ _) -> allocOp op >>= maybeBitcast mName targetTy
+      (PointerType _ _, _) -> maybeBitcast Nothing (PointerType targetTy (AddrSpace 0)) op >>= loadPointerToType mName targetTy
       (_, _) -> error $ "Failed to maybeConvertToPointer " ++ show (op, targetTy)
 
 allocOp :: Operand -> BlockGen Operand
@@ -35,20 +39,22 @@ allocOp op = do
   addInstruction $ Do $ Store False storeOp op Nothing 0 []
   pure storeOp
 
-loadPointerToType :: Type -> Operand -> BlockGen Operand
-loadPointerToType targetTy op = do
-  resultName <- freshUnName
+loadPointerToType :: Maybe Name -> Type -> Operand -> BlockGen Operand
+loadPointerToType mName targetTy op = do
+  resultName <- maybe freshUnName pure mName
   let resultOp = LocalReference targetTy resultName
   addInstruction $ resultName := Load False op Nothing 0 []
   pure resultOp
 
-maybeBitcast :: Type -> Operand -> BlockGen Operand
-maybeBitcast ty op =
+maybeBitcast :: Maybe Name -> Type -> Operand -> BlockGen Operand
+maybeBitcast mName ty op =
   -- Bitcast if we have to
   if operandType op == ty
-  then pure op
+  then do
+    for_ mName $ \name' -> bindOpToName name' op
+    pure op
   else do
-   ptrName <- freshUnName
+   ptrName <- maybe freshUnName pure mName
    let ptrOp = LocalReference ty ptrName
    addInstruction $ ptrName := BitCast op ty []
    pure ptrOp
@@ -85,3 +91,12 @@ someFloatType =
 --     FP128FP -> 128
 --     X86_FP80FP -> 80
 --     PPC_FP128FP -> 128
+
+bindOpToName :: Name -> Operand -> BlockGen ()
+bindOpToName name' op = do
+  storeName <- freshUnName
+  let
+    storeOp = LocalReference (PointerType (operandType op) (AddrSpace 0)) storeName
+  addInstruction $ storeName := Alloca (operandType op) Nothing 0 []
+  addInstruction $ Do $ Store False storeOp op Nothing 0 []
+  addInstruction $ name' := Load False storeOp Nothing 0 []

--- a/library/Amy/Codegen/TypeConversion.hs
+++ b/library/Amy/Codegen/TypeConversion.hs
@@ -3,6 +3,7 @@
 module Amy.Codegen.TypeConversion
   ( maybeConvertPointer
   , loadPointerToType
+  , operandType
   ) where
 
 import LLVM.AST


### PR DESCRIPTION
It seems silly to have these wonderful generated names in our ANF IR, but then totally ignore them when generating LLVM. This PR refactors the ANF IR and also uses the ANF IR names in codegen.