### PR TITLE
Allow polymorphic data types

### DIFF
--- a/examples/data.amy
+++ b/examples/data.amy
@@ -6,6 +6,8 @@ MySum = MySumA Int | MySumB Double | MySumC
 
 EmptyType
 
+Nat = Zero | Suc Nat
+
 main :: Int
 main =
   let
@@ -13,11 +15,12 @@ main =
     x = MySumB 7.8
     y :: MyEnum
     y = MyEnumB
+    z = Suc (Suc Zero)
   in
     case x of
       MySumA x' -> 0
       MySumB x' -> f x' y
-      MySumC -> 1
+      MySumC -> countNat z
 
 f :: Double -> MyEnum -> Int
 f x enum =
@@ -25,3 +28,9 @@ f x enum =
     MyEnumA -> 2
     MyEnumB -> doubleToInt# x
     MyEnumC -> 3
+
+countNat :: Nat -> Int
+countNat n =
+  case n of
+    Zero -> 0
+    Suc n' -> iAdd# 1 (countNat n')

--- a/examples/data.ll
+++ b/examples/data.ll
@@ -4,6 +4,7 @@
 source_filename = "<string>"
 
 %MySum = type { i8, i64* }
+%Nat = type { i1, i64* }
 
 define i64 @main() {
 entry:
@@ -18,37 +19,50 @@ entry:
   %4 = alloca i8
   store i8 1, i8* %4
   %y = load i8, i8* %4
-  %5 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %6 = load i8, i8* %5
-  %7 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %8 = load i64*, i64** %7
-  switch i8 %6, label %case.0.ret [
+  %z70 = alloca %Nat
+  %5 = getelementptr %Nat, %Nat* %z70, i32 0, i32 0
+  store i1 false, i1* %5
+  %z71 = alloca %Nat
+  %6 = getelementptr %Nat, %Nat* %z71, i32 0, i32 0
+  store i1 true, i1* %6
+  %7 = bitcast %Nat* %z70 to i64*
+  %8 = getelementptr %Nat, %Nat* %z71, i32 0, i32 1
+  store i64* %7, i64** %8
+  %z = alloca %Nat
+  %9 = getelementptr %Nat, %Nat* %z, i32 0, i32 0
+  store i1 true, i1* %9
+  %10 = bitcast %Nat* %z71 to i64*
+  %11 = getelementptr %Nat, %Nat* %z, i32 0, i32 1
+  store i64* %10, i64** %11
+  %12 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
+  %13 = load i8, i8* %12
+  %14 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
+  %15 = load i64*, i64** %14
+  switch i8 %13, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
     i8 2, label %case.2.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u47 = load i64, i64* %8
-  %9 = alloca i64
-  store i64 0, i64* %9
-  %10 = load i64, i64* %9
+  %_u63 = load i64, i64* %15
+  %16 = alloca i64
+  store i64 0, i64* %16
+  %17 = load i64, i64* %16
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %11 = bitcast i64* %8 to double*
-  %_u48 = load double, double* %11
-  %12 = call i64 @f(double %_u48, i8 %y)
+  %18 = bitcast i64* %15 to double*
+  %_u64 = load double, double* %18
+  %19 = call i64 @f(double %_u64, i8 %y)
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %13 = alloca i64
-  store i64 1, i64* %13
-  %14 = load i64, i64* %13
+  %20 = call i64 @countNat(%Nat* %z)
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %10, %case.0.ret ], [ %12, %case.1.ret ], [ %14, %case.2.ret ]
+  %ret = phi i64 [ %17, %case.0.ret ], [ %19, %case.1.ret ], [ %20, %case.2.ret ]
   ret i64 %ret
 }
 
@@ -78,6 +92,34 @@ case.2.ret:                                       ; preds = %entry
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
   %ret = phi i64 [ %1, %case.0.ret ], [ %2, %case.1.ret ], [ %4, %case.2.ret ]
+  ret i64 %ret
+}
+
+define private i64 @countNat(%Nat* %n) {
+entry:
+  %0 = getelementptr %Nat, %Nat* %n, i32 0, i32 0
+  %1 = load i1, i1* %0
+  %2 = getelementptr %Nat, %Nat* %n, i32 0, i32 1
+  %3 = load i64*, i64** %2
+  switch i1 %1, label %case.0.ret [
+    i1 false, label %case.0.ret
+    i1 true, label %case.1.ret
+  ]
+
+case.0.ret:                                       ; preds = %entry, %entry
+  %4 = alloca i64
+  store i64 0, i64* %4
+  %5 = load i64, i64* %4
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
+  %_u67 = bitcast i64* %3 to %Nat*
+  %res72 = call i64 @countNat(%Nat* %_u67)
+  %6 = add i64 1, %res72
+  br label %case.end.ret
+
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi i64 [ %5, %case.0.ret ], [ %6, %case.1.ret ]
   ret i64 %ret
 }
 

--- a/examples/poly-data.amy
+++ b/examples/poly-data.amy
@@ -1,0 +1,14 @@
+MyType x y = MyType x | B y
+
+f :: forall o. MyType Int o
+f =
+  case MyType 1 of
+    MyType i -> MyType i
+    B j -> B j
+
+
+g :: forall c d. c -> MyType c d
+g x = MyType x
+
+h :: forall a. MyType a Int
+h = B 1

--- a/examples/poly-data.amy
+++ b/examples/poly-data.amy
@@ -8,7 +8,7 @@ main =
 
 f :: forall o. MyType Int o
 f =
-  case MyType 1 of
+  case MyType 42 of
     MyType i -> MyType i
     B j -> B j
 

--- a/examples/poly-data.amy
+++ b/examples/poly-data.amy
@@ -1,5 +1,11 @@
 MyType x y = MyType x | B y
 
+main :: Int
+main =
+  case f of
+    MyType i -> i
+    B x -> 2
+
 f :: forall o. MyType Int o
 f =
   case MyType 1 of

--- a/examples/poly-data.amy
+++ b/examples/poly-data.amy
@@ -6,7 +6,6 @@ f =
     MyType i -> MyType i
     B j -> B j
 
-
 g :: forall c d. c -> MyType c d
 g x = MyType x
 

--- a/examples/poly-data.amy
+++ b/examples/poly-data.amy
@@ -1,19 +1,19 @@
-MyType x y = MyType x | B y
+Either a b = Left a | Right b
 
 main :: Int
 main =
   case f of
-    MyType i -> i
-    B x -> 2
+    Left i -> i
+    Right x -> 2
 
-f :: forall o. MyType Int o
+f :: forall b. Either Int b
 f =
-  case MyType 42 of
-    MyType i -> MyType i
-    B j -> B j
+  case Left 42 of
+    Left i -> Left i
+    Right j -> Right j
 
-g :: forall c d. c -> MyType c d
-g x = MyType x
+g :: forall c d. c -> Either c d
+g x = Left x
 
-h :: forall a. MyType a Int
-h = B 1
+h :: forall a. Either a Int
+h = Right 1

--- a/examples/poly-data.ll
+++ b/examples/poly-data.ll
@@ -1,0 +1,111 @@
+; Generated from examples/poly-data.amy
+
+; ModuleID = 'amy-module'
+source_filename = "<string>"
+
+%MyType = type { i1, i64* }
+
+define i64 @main() {
+entry:
+  %res77 = call %MyType* @f()
+  %0 = getelementptr %MyType, %MyType* %res77, i32 0, i32 0
+  %1 = load i1, i1* %0
+  %2 = getelementptr %MyType, %MyType* %res77, i32 0, i32 1
+  %3 = load i64*, i64** %2
+  switch i1 %1, label %case.0.ret [
+    i1 false, label %case.0.ret
+    i1 true, label %case.1.ret
+  ]
+
+case.0.ret:                                       ; preds = %entry, %entry
+  %4 = alloca i64*
+  store i64* %3, i64** %4
+  %_u70 = load i64*, i64** %4
+  %5 = alloca i64
+  store i64* %_u70, i64* %5
+  %6 = load i64, i64* %5
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
+  %7 = alloca i64*
+  store i64* %3, i64** %7
+  %_u71 = load i64*, i64** %7
+  %8 = alloca i64
+  store i64 2, i64* %8
+  %9 = load i64, i64* %8
+  br label %case.end.ret
+
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi i64 [ %6, %case.0.ret ], [ %9, %case.1.ret ]
+  ret i64 %ret
+}
+
+define private %MyType* @f() {
+entry:
+  %res78 = alloca %MyType
+  %0 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
+  store i1 false, i1* %0
+  %1 = alloca i64
+  store i64 1, i64* %1
+  %2 = getelementptr %MyType, %MyType* %res78, i32 0, i32 1
+  store i64* %1, i64** %2
+  %3 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
+  %4 = load i1, i1* %3
+  %5 = getelementptr %MyType, %MyType* %res78, i32 0, i32 1
+  %6 = load i64*, i64** %5
+  switch i1 %4, label %case.0.ret [
+    i1 false, label %case.0.ret
+    i1 true, label %case.1.ret
+  ]
+
+case.0.ret:                                       ; preds = %entry, %entry
+  %7 = alloca i64*
+  store i64* %6, i64** %7
+  %_u73 = load i64*, i64** %7
+  %8 = alloca %MyType
+  %9 = getelementptr %MyType, %MyType* %8, i32 0, i32 0
+  store i1 false, i1* %9
+  %10 = alloca i64
+  store i64* %_u73, i64* %10
+  %11 = getelementptr %MyType, %MyType* %8, i32 0, i32 1
+  store i64* %10, i64** %11
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
+  %12 = alloca i64*
+  store i64* %6, i64** %12
+  %_u74 = load i64*, i64** %12
+  %13 = alloca %MyType
+  %14 = getelementptr %MyType, %MyType* %13, i32 0, i32 0
+  store i1 true, i1* %14
+  %15 = getelementptr %MyType, %MyType* %13, i32 0, i32 1
+  store i64* %_u74, i64** %15
+  br label %case.end.ret
+
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi %MyType* [ %8, %case.0.ret ], [ %13, %case.1.ret ]
+  ret %MyType* %ret
+}
+
+define private %MyType* @g(i64* %x) {
+entry:
+  %ret = alloca %MyType
+  %0 = getelementptr %MyType, %MyType* %ret, i32 0, i32 0
+  store i1 false, i1* %0
+  %1 = getelementptr %MyType, %MyType* %ret, i32 0, i32 1
+  store i64* %x, i64** %1
+  ret %MyType* %ret
+}
+
+define private %MyType* @h() {
+entry:
+  %ret = alloca %MyType
+  %0 = getelementptr %MyType, %MyType* %ret, i32 0, i32 0
+  store i1 true, i1* %0
+  %1 = alloca i64
+  store i64 1, i64* %1
+  %2 = getelementptr %MyType, %MyType* %ret, i32 0, i32 1
+  store i64* %1, i64** %2
+  ret %MyType* %ret
+}
+

--- a/examples/poly-data.ll
+++ b/examples/poly-data.ll
@@ -18,25 +18,23 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %4 = alloca i64*
-  store i64* %3, i64** %4
-  %_u70 = load i64*, i64** %4
-  %5 = alloca i64
-  store i64* %_u70, i64* %5
-  %6 = load i64, i64* %5
+  %_u70 = load i64, i64* %3
+  %4 = alloca i64
+  store i64 %_u70, i64* %4
+  %5 = load i64, i64* %4
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %7 = alloca i64*
-  store i64* %3, i64** %7
-  %_u71 = load i64*, i64** %7
-  %8 = alloca i64
-  store i64 2, i64* %8
-  %9 = load i64, i64* %8
+  %6 = alloca i64*
+  store i64* %3, i64** %6
+  %_u71 = load i64*, i64** %6
+  %7 = alloca i64
+  store i64 2, i64* %7
+  %8 = load i64, i64* %7
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %6, %case.0.ret ], [ %9, %case.1.ret ]
+  %ret = phi i64 [ %5, %case.0.ret ], [ %8, %case.1.ret ]
   ret i64 %ret
 }
 
@@ -46,7 +44,7 @@ entry:
   %0 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
   store i1 false, i1* %0
   %1 = alloca i64
-  store i64 1, i64* %1
+  store i64 42, i64* %1
   %2 = getelementptr %MyType, %MyType* %res78, i32 0, i32 1
   store i64* %1, i64** %2
   %3 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
@@ -59,31 +57,29 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %7 = alloca i64*
-  store i64* %6, i64** %7
-  %_u73 = load i64*, i64** %7
-  %8 = alloca %MyType
-  %9 = getelementptr %MyType, %MyType* %8, i32 0, i32 0
-  store i1 false, i1* %9
-  %10 = alloca i64
-  store i64* %_u73, i64* %10
-  %11 = getelementptr %MyType, %MyType* %8, i32 0, i32 1
-  store i64* %10, i64** %11
+  %_u73 = load i64, i64* %6
+  %7 = alloca %MyType
+  %8 = getelementptr %MyType, %MyType* %7, i32 0, i32 0
+  store i1 false, i1* %8
+  %9 = alloca i64
+  store i64 %_u73, i64* %9
+  %10 = getelementptr %MyType, %MyType* %7, i32 0, i32 1
+  store i64* %9, i64** %10
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %12 = alloca i64*
-  store i64* %6, i64** %12
-  %_u74 = load i64*, i64** %12
-  %13 = alloca %MyType
-  %14 = getelementptr %MyType, %MyType* %13, i32 0, i32 0
-  store i1 true, i1* %14
-  %15 = getelementptr %MyType, %MyType* %13, i32 0, i32 1
-  store i64* %_u74, i64** %15
+  %11 = alloca i64*
+  store i64* %6, i64** %11
+  %_u74 = load i64*, i64** %11
+  %12 = alloca %MyType
+  %13 = getelementptr %MyType, %MyType* %12, i32 0, i32 0
+  store i1 true, i1* %13
+  %14 = getelementptr %MyType, %MyType* %12, i32 0, i32 1
+  store i64* %_u74, i64** %14
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi %MyType* [ %8, %case.0.ret ], [ %13, %case.1.ret ]
+  %ret = phi %MyType* [ %7, %case.0.ret ], [ %12, %case.1.ret ]
   ret %MyType* %ret
 }
 

--- a/examples/poly-data.ll
+++ b/examples/poly-data.ll
@@ -3,14 +3,14 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-%MyType = type { i1, i64* }
+%Either = type { i1, i64* }
 
 define i64 @main() {
 entry:
-  %res77 = call %MyType* @f()
-  %0 = getelementptr %MyType, %MyType* %res77, i32 0, i32 0
+  %res77 = call %Either* @f()
+  %0 = getelementptr %Either, %Either* %res77, i32 0, i32 0
   %1 = load i1, i1* %0
-  %2 = getelementptr %MyType, %MyType* %res77, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res77, i32 0, i32 1
   %3 = load i64*, i64** %2
   switch i1 %1, label %case.0.ret [
     i1 false, label %case.0.ret
@@ -38,18 +38,18 @@ case.end.ret:                                     ; preds = %case.1.ret, %case.0
   ret i64 %ret
 }
 
-define private %MyType* @f() {
+define private %Either* @f() {
 entry:
-  %res78 = alloca %MyType
-  %0 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
+  %res78 = alloca %Either
+  %0 = getelementptr %Either, %Either* %res78, i32 0, i32 0
   store i1 false, i1* %0
   %1 = alloca i64
   store i64 42, i64* %1
-  %2 = getelementptr %MyType, %MyType* %res78, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res78, i32 0, i32 1
   store i64* %1, i64** %2
-  %3 = getelementptr %MyType, %MyType* %res78, i32 0, i32 0
+  %3 = getelementptr %Either, %Either* %res78, i32 0, i32 0
   %4 = load i1, i1* %3
-  %5 = getelementptr %MyType, %MyType* %res78, i32 0, i32 1
+  %5 = getelementptr %Either, %Either* %res78, i32 0, i32 1
   %6 = load i64*, i64** %5
   switch i1 %4, label %case.0.ret [
     i1 false, label %case.0.ret
@@ -58,12 +58,12 @@ entry:
 
 case.0.ret:                                       ; preds = %entry, %entry
   %_u73 = load i64, i64* %6
-  %7 = alloca %MyType
-  %8 = getelementptr %MyType, %MyType* %7, i32 0, i32 0
+  %7 = alloca %Either
+  %8 = getelementptr %Either, %Either* %7, i32 0, i32 0
   store i1 false, i1* %8
   %9 = alloca i64
   store i64 %_u73, i64* %9
-  %10 = getelementptr %MyType, %MyType* %7, i32 0, i32 1
+  %10 = getelementptr %Either, %Either* %7, i32 0, i32 1
   store i64* %9, i64** %10
   br label %case.end.ret
 
@@ -71,37 +71,37 @@ case.1.ret:                                       ; preds = %entry
   %11 = alloca i64*
   store i64* %6, i64** %11
   %_u74 = load i64*, i64** %11
-  %12 = alloca %MyType
-  %13 = getelementptr %MyType, %MyType* %12, i32 0, i32 0
+  %12 = alloca %Either
+  %13 = getelementptr %Either, %Either* %12, i32 0, i32 0
   store i1 true, i1* %13
-  %14 = getelementptr %MyType, %MyType* %12, i32 0, i32 1
+  %14 = getelementptr %Either, %Either* %12, i32 0, i32 1
   store i64* %_u74, i64** %14
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi %MyType* [ %7, %case.0.ret ], [ %12, %case.1.ret ]
-  ret %MyType* %ret
+  %ret = phi %Either* [ %7, %case.0.ret ], [ %12, %case.1.ret ]
+  ret %Either* %ret
 }
 
-define private %MyType* @g(i64* %x) {
+define private %Either* @g(i64* %x) {
 entry:
-  %ret = alloca %MyType
-  %0 = getelementptr %MyType, %MyType* %ret, i32 0, i32 0
+  %ret = alloca %Either
+  %0 = getelementptr %Either, %Either* %ret, i32 0, i32 0
   store i1 false, i1* %0
-  %1 = getelementptr %MyType, %MyType* %ret, i32 0, i32 1
+  %1 = getelementptr %Either, %Either* %ret, i32 0, i32 1
   store i64* %x, i64** %1
-  ret %MyType* %ret
+  ret %Either* %ret
 }
 
-define private %MyType* @h() {
+define private %Either* @h() {
 entry:
-  %ret = alloca %MyType
-  %0 = getelementptr %MyType, %MyType* %ret, i32 0, i32 0
+  %ret = alloca %Either
+  %0 = getelementptr %Either, %Either* %ret, i32 0, i32 0
   store i1 true, i1* %0
   %1 = alloca i64
   store i64 1, i64* %1
-  %2 = getelementptr %MyType, %MyType* %ret, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %ret, i32 0, i32 1
   store i64* %1, i64** %2
-  ret %MyType* %ret
+  ret %Either* %ret
 }
 

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -40,11 +40,11 @@ convertTypeDeclaration :: C.TypeDeclaration -> ANFConvert ANF.TypeDeclaration
 convertTypeDeclaration (C.TypeDeclaration tyConInfo con) = do
   ty <- getTyConInfoType tyConInfo
   con' <- traverse convertDataConstructor con
-  pure $ ANF.TypeDeclaration (C.tyConInfoText tyConInfo) ty con'
+  pure $ ANF.TypeDeclaration (C.tyConInfoName tyConInfo) ty con'
 
 convertDataConstructor :: C.DataConstructor -> ANFConvert ANF.DataConstructor
 convertDataConstructor (C.DataConstructor conName id' mTyArg tyCon span' index) = do
-  mTyArg' <- traverse getTyConInfoType mTyArg
+  mTyArg' <- traverse convertTyArg mTyArg
   tyCon' <- getTyConInfoType tyCon
   pure
     ANF.DataConstructor
@@ -55,6 +55,10 @@ convertDataConstructor (C.DataConstructor conName id' mTyArg tyCon span' index) 
     , ANF.dataConstructorSpan = span'
     , ANF.dataConstructorIndex = index
     }
+
+convertTyArg :: C.TyArg -> ANFConvert ANF.Type
+convertTyArg (C.TyConArg con) = getTyConInfoType con
+convertTyArg (C.TyVarArg _) = pure OpaquePointerType
 
 convertDataConInfo :: C.DataConInfo -> ANFConvert ANF.DataConInfo
 convertDataConInfo (C.DataConInfo typeDecl dataCon) = do

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -37,10 +37,10 @@ convertExtern :: C.Extern -> ANFConvert ANF.Extern
 convertExtern (C.Extern name ty) = ANF.Extern (convertIdent True name) <$> convertType ty
 
 convertTypeDeclaration :: C.TypeDeclaration -> ANFConvert ANF.TypeDeclaration
-convertTypeDeclaration (C.TypeDeclaration tyConInfo con) = do
-  ty <- getTyConInfoType tyConInfo
+convertTypeDeclaration (C.TypeDeclaration tyConDef con) = do
+  ty <- getTyConDefinitionType tyConDef
   con' <- traverse convertDataConstructor con
-  pure $ ANF.TypeDeclaration (C.tyConInfoName tyConInfo) ty con'
+  pure $ ANF.TypeDeclaration (C.tyConDefinitionName tyConDef) ty con'
 
 convertDataConstructor :: C.DataConstructor -> ANFConvert ANF.DataConstructor
 convertDataConstructor (C.DataConstructor conName id' mTyArg tyCon span' index) = do

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -9,6 +9,7 @@ module Amy.ANF.Monad
   , anfConvertState
   , freshId
   , freshIdent
+  , getTyConDefinitionType
   , getTyConInfoType
   , isIdentTopLevel
   ) where
@@ -44,7 +45,7 @@ anfConvertRead :: [C.Ident] -> [C.TypeDeclaration] -> ANFConvertRead
 anfConvertRead topLevelNames typeDeclarations =
   let
     allTypeDecls = typeDeclarations ++ (fromPrimTypeDefinition <$> allPrimTypeDefinitions)
-    typeRepMap = Map.fromList $ (\t -> (C.tyConInfoId $ C.typeDeclarationTypeName t, typeRep t)) <$> allTypeDecls
+    typeRepMap = Map.fromList $ (\t -> (C.tyConDefinitionId $ C.typeDeclarationTypeName t, typeRep t)) <$> allTypeDecls
   in
     ANFConvertRead
     { anfConvertReadTypeReps = typeRepMap
@@ -68,6 +69,11 @@ freshIdent :: Text -> ANFConvert ANF.Ident
 freshIdent t = do
   id' <- freshId
   pure $ ANF.Ident (t <> pack (show id')) id' False
+
+getTyConDefinitionType :: C.TyConDefinition -> ANFConvert ANF.Type
+getTyConDefinitionType tyCon = fromMaybe err . Map.lookup (tyConDefinitionId tyCon) <$> asks anfConvertReadTypeReps
+  where
+   err = error $ "Couldn't find TypeCompilationMethod of TyConDefinition " ++ show tyCon
 
 getTyConInfoType :: C.TyConInfo -> ANFConvert ANF.Type
 getTyConInfoType tyCon = fromMaybe err . Map.lookup (tyConInfoId tyCon) <$> asks anfConvertReadTypeReps

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -36,7 +36,7 @@ runANFConvert read' state' (ANFConvert action) = evalState (runReaderT action re
 
 data ANFConvertRead
   = ANFConvertRead
-  { anfConvertReadTypeReps :: !(Map C.TyConInfo ANF.Type)
+  { anfConvertReadTypeReps :: !(Map Int ANF.Type)
   , anfConvertReadTopLevelNames :: !(Set C.Ident)
   } deriving (Show, Eq)
 
@@ -44,7 +44,7 @@ anfConvertRead :: [C.Ident] -> [C.TypeDeclaration] -> ANFConvertRead
 anfConvertRead topLevelNames typeDeclarations =
   let
     allTypeDecls = typeDeclarations ++ (fromPrimTypeDefinition <$> allPrimTypeDefinitions)
-    typeRepMap = Map.fromList $ (\t -> (C.typeDeclarationTypeName t, typeRep t)) <$> allTypeDecls
+    typeRepMap = Map.fromList $ (\t -> (C.tyConInfoId $ C.typeDeclarationTypeName t, typeRep t)) <$> allTypeDecls
   in
     ANFConvertRead
     { anfConvertReadTypeReps = typeRepMap
@@ -70,7 +70,7 @@ freshIdent t = do
   pure $ ANF.Ident (t <> pack (show id')) id' False
 
 getTyConInfoType :: C.TyConInfo -> ANFConvert ANF.Type
-getTyConInfoType tyCon = fromMaybe err . Map.lookup tyCon <$> asks anfConvertReadTypeReps
+getTyConInfoType tyCon = fromMaybe err . Map.lookup (tyConInfoId tyCon) <$> asks anfConvertReadTypeReps
   where
    err = error $ "Couldn't find TypeCompilationMethod of TyConInfo " ++ show tyCon
 

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -29,7 +29,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName _ cons) =
-   prettyTypeDeclaration (pretty tyName) [] (prettyConstructor <$> cons)
+   prettyTypeDeclaration (pretty tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyType . mkPrettyType <$> mArg)

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -29,7 +29,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName _ cons) =
-   prettyTypeDeclaration (pretty tyName) (prettyConstructor <$> cons)
+   prettyTypeDeclaration (pretty tyName) [] (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyType . mkPrettyType <$> mArg)

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -79,4 +79,5 @@ prettyLetValBinding (LetValBinding ident ty body) =
 prettyPattern :: Pattern -> Doc ann
 prettyPattern (PLit lit) = pretty $ showLiteral lit
 prettyPattern (PCons (PatCons cons mArg _)) =
-  pretty (dataConstructorName $ dataConInfoCons cons) <> maybe mempty (\(Typed _ arg) -> space <> prettyIdent arg) mArg
+  pretty (dataConstructorName $ dataConInfoCons cons)
+  <> maybe mempty (\(Typed ty arg) -> space <> parens (prettyIdent arg <+> "::" <+> prettyType (mkPrettyType ty))) mArg

--- a/library/Amy/ANF/TypeRep.hs
+++ b/library/Amy/ANF/TypeRep.hs
@@ -32,7 +32,7 @@ typeRep (C.TypeDeclaration tyName constructors) =
       if all (isNothing . C.dataConstructorArgument) constructors
       then EnumType wordSize
       -- Can't do an enum. We'll have to use tagged pairs.
-      else TaggedUnionType (tyConInfoName tyName) wordSize
+      else TaggedUnionType (tyConDefinitionName tyName) wordSize
  where
   -- Pick a proper integer size
   wordSize :: Word32
@@ -41,8 +41,8 @@ typeRep (C.TypeDeclaration tyName constructors) =
       | length constructors < (2 :: Int) ^ (8 :: Int) -> 8
       | otherwise -> 32
 
-maybePrimitiveType :: C.TyConInfo -> Maybe ANF.Type
-maybePrimitiveType (C.TyConInfo _ id' _ _)
+maybePrimitiveType :: C.TyConDefinition -> Maybe ANF.Type
+maybePrimitiveType (C.TyConDefinition _ id' _ _)
   | id' == intTyConId = Just PrimIntType
   | id' == doubleTyConId = Just PrimDoubleType
   | otherwise = Nothing

--- a/library/Amy/ANF/TypeRep.hs
+++ b/library/Amy/ANF/TypeRep.hs
@@ -32,7 +32,7 @@ typeRep (C.TypeDeclaration tyName constructors) =
       if all (isNothing . C.dataConstructorArgument) constructors
       then EnumType wordSize
       -- Can't do an enum. We'll have to use tagged pairs.
-      else TaggedUnionType (tyConInfoText tyName) wordSize
+      else TaggedUnionType (tyConInfoName tyName) wordSize
  where
   -- Pick a proper integer size
   wordSize :: Word32
@@ -42,7 +42,7 @@ typeRep (C.TypeDeclaration tyName constructors) =
       | otherwise -> 32
 
 maybePrimitiveType :: C.TyConInfo -> Maybe ANF.Type
-maybePrimitiveType (C.TyConInfo _ id' _)
+maybePrimitiveType (C.TyConInfo _ id' _ _)
   | id' == intTyConId = Just PrimIntType
   | id' == doubleTyConId = Just PrimDoubleType
   | otherwise = Nothing

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -83,12 +83,15 @@ data TyConDefinition
   , tyConDefinitionKind :: !Kind
   } deriving (Show, Eq, Ord)
 
-definitionFromPrimTyCon :: PrimTyCon -> TyConDefinition
-definitionFromPrimTyCon (PrimTyCon name id') = TyConDefinition name id' [] KStar
+tyConDefinitionToInfo :: TyConDefinition -> TyConInfo
+tyConDefinitionToInfo tyDef@(TyConDefinition name' id' args _) = TyConInfo name' id' (TyVarArg <$> args) tyDef
+
+fromPrimTyDef :: PrimTyCon -> TyConDefinition
+fromPrimTyDef (PrimTyCon name id') = TyConDefinition name id' [] KStar
 
 fromPrimTypeDefinition :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDefinition (PrimTypeDefinition tyName cons) =
-  TypeDeclaration (definitionFromPrimTyCon tyName) (fromPrimDataCon <$> cons)
+  TypeDeclaration (fromPrimTyDef tyName) (fromPrimDataCon <$> cons)
 
 data DataConstructor
   = DataConstructor
@@ -242,11 +245,11 @@ data TyConInfo
   { tyConInfoName :: !Text
   , tyConInfoId :: !Int
   , tyConInfoArgs :: ![TyArg]
-  , tyConInfoKind :: !Kind
+  , tyConInfoDefinition :: !TyConDefinition
   } deriving (Show, Eq, Ord)
 
 fromPrimTyCon :: PrimTyCon -> TyConInfo
-fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' [] KStar
+fromPrimTyCon = tyConDefinitionToInfo . fromPrimTyDef
 
 data TyVarInfo
   = TyVarInfo

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -5,6 +5,7 @@ module Amy.Core.AST
   , Binding(..)
   , Extern(..)
   , TypeDeclaration(..)
+  , TyConDefinition(..)
   , fromPrimTypeDefinition
   , DataConstructor(..)
   , DataConInfo(..)
@@ -70,13 +71,24 @@ data Extern
 
 data TypeDeclaration
   = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConInfo
+  { typeDeclarationTypeName :: !TyConDefinition
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq, Ord)
 
+data TyConDefinition
+  = TyConDefinition
+  { tyConDefinitionName :: !Text
+  , tyConDefinitionId :: !Int
+  , tyConDefinitionArgs :: ![TyVarInfo]
+  , tyConDefinitionKind :: !Kind
+  } deriving (Show, Eq, Ord)
+
+definitionFromPrimTyCon :: PrimTyCon -> TyConDefinition
+definitionFromPrimTyCon (PrimTyCon name id') = TyConDefinition name id' [] KStar
+
 fromPrimTypeDefinition :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDefinition (PrimTypeDefinition tyName cons) =
-  TypeDeclaration (fromPrimTyCon tyName) (fromPrimDataCon <$> cons)
+  TypeDeclaration (definitionFromPrimTyCon tyName) (fromPrimDataCon <$> cons)
 
 data DataConstructor
   = DataConstructor

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -22,6 +22,7 @@ module Amy.Core.AST
   , Ident(..)
   , substExpr
   , Type(..)
+  , TyArg(..)
   , TyConInfo(..)
   , TyVarInfo(..)
   , Scheme(..)
@@ -81,7 +82,7 @@ data DataConstructor
   = DataConstructor
   { dataConstructorName :: !Text
   , dataConstructorId :: !Int
-  , dataConstructorArgument :: !(Maybe TyConInfo)
+  , dataConstructorArgument :: !(Maybe TyArg)
   , dataConstructorType :: !TyConInfo
   , dataConstructorSpan :: !ConstructorSpan
   , dataConstructorIndex :: !ConstructorIndex
@@ -226,13 +227,14 @@ infixr 0 `TyFun`
 
 data TyConInfo
   = TyConInfo
-  { tyConInfoText :: !Text
+  { tyConInfoName :: !Text
   , tyConInfoId :: !Int
+  , tyConInfoArgs :: ![TyArg]
   , tyConInfoKind :: !Kind
   } deriving (Show, Eq, Ord)
 
 fromPrimTyCon :: PrimTyCon -> TyConInfo
-fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' KStar
+fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' [] KStar
 
 data TyVarInfo
   = TyVarInfo
@@ -240,6 +242,11 @@ data TyVarInfo
   , tyVarInfoId :: !Int
   , tyVarInfoKind :: !Kind
   } deriving (Show, Eq, Ord)
+
+data TyArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
+  deriving (Show, Eq, Ord)
 
 data Scheme
   = Forall ![TyVarInfo] Type

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -129,10 +129,7 @@ desugarTyConInfo :: T.TyConInfo -> C.TyConInfo
 desugarTyConInfo (T.TyConInfo name id' args kind) = C.TyConInfo name id' (desugarTyArg <$> args) kind
 
 desugarTyVarInfo :: T.TyVarInfo -> C.TyVarInfo
-desugarTyVarInfo ty@(T.TyVarInfo name id' kind gen) =
-  case gen of
-    TyVarGenerated -> error $ "Found generated type name, bad! " ++ show ty
-    TyVarNotGenerated -> C.TyVarInfo name id' kind
+desugarTyVarInfo (T.TyVarInfo name id' kind _) = C.TyVarInfo name id' kind
 
 --
 -- Case Expressions

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -28,7 +28,7 @@ desugarExtern (T.Extern ident ty) =
 
 desugarTypeDeclaration :: T.TypeDeclaration -> C.TypeDeclaration
 desugarTypeDeclaration (T.TypeDeclaration tyName cons) =
-  C.TypeDeclaration (desugarTyConInfo tyName) (desugarDataConstructor <$> cons)
+  C.TypeDeclaration (desugarTyConDefinition tyName) (desugarDataConstructor <$> cons)
 
 desugarDataConstructor :: T.DataConstructor -> C.DataConstructor
 desugarDataConstructor (T.DataConstructor conName id' mTyArg tyCon span' index) =
@@ -124,6 +124,9 @@ desugarType :: T.Type -> C.Type
 desugarType (T.TyCon info) = C.TyCon (desugarTyConInfo info)
 desugarType (T.TyVar info) = C.TyVar (desugarTyVarInfo info)
 desugarType (T.TyFun ty1 ty2) = C.TyFun (desugarType ty1) (desugarType ty2)
+
+desugarTyConDefinition :: T.TyConDefinition -> C.TyConDefinition
+desugarTyConDefinition (T.TyConDefinition name id' args kind) = C.TyConDefinition name id' (desugarTyVarInfo <$> args) kind
 
 desugarTyConInfo :: T.TyConInfo -> C.TyConInfo
 desugarTyConInfo (T.TyConInfo name id' args kind) = C.TyConInfo name id' (desugarTyArg <$> args) kind

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -151,9 +151,7 @@ convertPattern (T.PCons (T.PatCons info mArg _)) =
   let
     info' = desugarDataConInfo info
     argPats = convertPattern <$> maybeToList mArg
-    tyArgToType (C.TyConArg con) = C.TyCon con
-    tyArgToType (C.TyVarArg var) = C.TyVar var
-    argTys = tyArgToType <$> maybeToList (C.dataConstructorArgument (C.dataConInfoCons info'))
+    argTys = maybeToList $ desugarType . patternType <$> mArg
     (ConstructorSpan span') = C.dataConstructorSpan $ C.dataConInfoCons info'
   in PC.PCon (PC.Con info' argTys span') argPats
 convertPattern (T.PParens pat) = convertPattern pat

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -129,7 +129,7 @@ desugarTyConDefinition :: T.TyConDefinition -> C.TyConDefinition
 desugarTyConDefinition (T.TyConDefinition name id' args kind) = C.TyConDefinition name id' (desugarTyVarInfo <$> args) kind
 
 desugarTyConInfo :: T.TyConInfo -> C.TyConInfo
-desugarTyConInfo (T.TyConInfo name id' args kind) = C.TyConInfo name id' (desugarTyArg <$> args) kind
+desugarTyConInfo (T.TyConInfo name id' args tyDef) = C.TyConInfo name id' (desugarTyArg <$> args) (desugarTyConDefinition tyDef)
 
 desugarTyVarInfo :: T.TyVarInfo -> C.TyVarInfo
 desugarTyVarInfo (T.TyVarInfo name id' kind _) = C.TyVarInfo name id' kind

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -90,4 +90,5 @@ prettyVar (VCons (Typed _ cons)) = pretty . dataConstructorName . dataConInfoCon
 prettyPattern :: Pattern -> Doc ann
 prettyPattern (PLit lit) = pretty $ showLiteral lit
 prettyPattern (PCons (PatCons cons mArg _)) =
-  pretty (dataConstructorName $ dataConInfoCons cons) <> maybe mempty (\(Typed _ arg) -> space <> prettyIdent arg) mArg
+  pretty (dataConstructorName $ dataConInfoCons cons)
+  <> maybe mempty (\(Typed ty arg) -> space <> parens (prettyIdent arg <+> "::" <+> prettyType (mkPrettyType ty))) mArg

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -38,7 +38,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConInfo tyName) [] (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -40,10 +40,15 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConDefinition tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
+
+prettyTyConDefinition :: TyConDefinition -> Doc ann
+prettyTyConDefinition (TyConDefinition name _ args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else space <> sep (prettyTyVarInfo <$> args)
 
 prettyTyArg :: TyArg -> Doc ann
 prettyTyArg (TyConArg info) = prettyTyConInfo info

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -38,7 +38,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) [] (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -17,7 +17,9 @@ mkPrettyType (TyVar name) = PTyDoc $ prettyTyVarInfo name
 mkPrettyType (TyFun ty1 ty2) = PTyFun (mkPrettyType ty1) (mkPrettyType ty2)
 
 prettyTyConInfo :: TyConInfo -> Doc ann
-prettyTyConInfo (TyConInfo name _ _) = pretty name
+prettyTyConInfo (TyConInfo name _ args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else space <> sep (prettyTyArg <$> args)
 
 prettyTyVarInfo :: TyVarInfo -> Doc ann
 prettyTyVarInfo (TyVarInfo name _ _) = pretty name
@@ -41,7 +43,11 @@ prettyTypeDeclaration' (TypeDeclaration tyName cons) =
    prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
-    prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)
+    prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
+
+prettyTyArg :: TyArg -> Doc ann
+prettyTyArg (TyConArg info) = prettyTyConInfo info
+prettyTyArg (TyVarArg info) = prettyTyVarInfo info
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding ident scheme args _ body) =

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -13,7 +13,7 @@ import Text.Megaparsec
 
 import Amy.ANF.AST as ANF
 import Amy.Renamer.AST as R
-import Amy.Syntax.Located
+import Amy.Syntax.AST as S
 import Amy.TypeCheck.AST as T
 
 data Error
@@ -23,8 +23,9 @@ data Error
   -- Renamer
   | UnknownVariable !(Located Text)
   | VariableShadowed !(Located Text) !(Located R.Ident)
+  | TypeConstructorDefinitionContainsTyCon !S.TyConInfo
   | DuplicateDataConstructorName !(Located Text) !R.DataConstructor
-  | DuplicateTypeVariable !R.TyVarInfo !R.TyVarInfo
+  | DuplicateTypeVariable !(Located Text) !(Located Text)
   | TypeConstructorAlreadyExists !(Located Text) !R.TyConInfo
   | UnknownTypeConstructor !(Located Text)
   | UnknownTypeVariable !(Located Text)
@@ -57,8 +58,9 @@ errorLocation e =
     ParserError{} -> Nothing
     UnknownVariable (Located s _) -> Just s
     VariableShadowed (Located s _) _ -> Just s
+    TypeConstructorDefinitionContainsTyCon (S.TyConInfo _ _ s) -> Just s
     DuplicateDataConstructorName (Located s _) _ -> Just s
-    DuplicateTypeVariable (R.TyVarInfo _ _ s) _ -> Just s
+    DuplicateTypeVariable (Located s _) _ -> Just s
     TypeConstructorAlreadyExists (Located s _) _ -> Just s
     UnknownTypeConstructor (Located s _) -> Just s
     UnknownTypeVariable (Located s _) -> Just s

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -24,6 +24,7 @@ data Error
   | UnknownVariable !(Located Text)
   | VariableShadowed !(Located Text) !(Located R.Ident)
   | DuplicateDataConstructorName !(Located Text) !R.DataConstructor
+  | DuplicateTypeVariable !R.TyVarInfo !R.TyVarInfo
   | TypeConstructorAlreadyExists !(Located Text) !R.TyConInfo
   | UnknownTypeConstructor !(Located Text)
   | UnknownTypeVariable !(Located Text)
@@ -57,6 +58,7 @@ errorLocation e =
     UnknownVariable (Located s _) -> Just s
     VariableShadowed (Located s _) _ -> Just s
     DuplicateDataConstructorName (Located s _) _ -> Just s
+    DuplicateTypeVariable (R.TyVarInfo _ _ s) _ -> Just s
     TypeConstructorAlreadyExists (Located s _) _ -> Just s
     UnknownTypeConstructor (Located s _) -> Just s
     UnknownTypeVariable (Located s _) -> Just s

--- a/library/Amy/Pretty.hs
+++ b/library/Amy/Pretty.hs
@@ -132,8 +132,8 @@ prettyBindingScheme name scheme = name <+> "::" <+> prettyScheme scheme
 prettyExtern :: Doc ann -> PrettyType ann -> Doc ann
 prettyExtern name ty = "extern" <+> prettyBindingType name ty
 
-prettyTypeDeclaration :: Doc ann -> [Doc ann] -> Doc ann
-prettyTypeDeclaration tyName dataCons = tyName <>
+prettyTypeDeclaration :: Doc ann -> [Doc ann] -> [Doc ann] -> Doc ann
+prettyTypeDeclaration tyName tyVars dataCons = tyName <> sep ((space <>) <$> tyVars) <>
   case dataCons of
     [] -> mempty
     _ -> space <> "=" <+> concatWith (\l r -> l <+> "|" <+> r) dataCons

--- a/library/Amy/Pretty.hs
+++ b/library/Amy/Pretty.hs
@@ -132,8 +132,8 @@ prettyBindingScheme name scheme = name <+> "::" <+> prettyScheme scheme
 prettyExtern :: Doc ann -> PrettyType ann -> Doc ann
 prettyExtern name ty = "extern" <+> prettyBindingType name ty
 
-prettyTypeDeclaration :: Doc ann -> [Doc ann] -> [Doc ann] -> Doc ann
-prettyTypeDeclaration tyName tyVars dataCons = tyName <> sep ((space <>) <$> tyVars) <>
+prettyTypeDeclaration :: Doc ann -> [Doc ann] -> Doc ann
+prettyTypeDeclaration tyName dataCons = tyName <>
   case dataCons of
     [] -> mempty
     _ -> space <> "=" <+> concatWith (\l r -> l <+> "|" <+> r) dataCons

--- a/library/Amy/Renamer/AST.hs
+++ b/library/Amy/Renamer/AST.hs
@@ -5,6 +5,8 @@ module Amy.Renamer.AST
   , Binding(..)
   , Extern(..)
   , TypeDeclaration(..)
+  , TyConDefinition(..)
+  , tyConDefinitionToInfo
   , fromPrimTypeDef
   , DataConstructor(..)
   , DataConInfo(..)
@@ -69,13 +71,27 @@ data Extern
 
 data TypeDeclaration
   = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConInfo
+  { typeDeclarationTypeName :: !TyConDefinition
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq)
 
+data TyConDefinition
+  = TyConDefinition
+  { tyConDefinitionName :: !Text
+  , tyConDefinitionId :: !Int
+  , tyConDefinitionArgs :: ![TyVarInfo]
+  , tyConDefinitionLocation :: !(Maybe SourceSpan)
+  } deriving (Show, Eq)
+
+tyConDefinitionToInfo :: TyConDefinition -> TyConInfo
+tyConDefinitionToInfo (TyConDefinition name' id' args span') = TyConInfo name' id' (TyVarArg <$> args) span'
+
+fromPrimTyDef :: PrimTyCon -> TyConDefinition
+fromPrimTyDef (PrimTyCon name id') = TyConDefinition name id' [] Nothing
+
 fromPrimTypeDef :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDef (PrimTypeDefinition tyCon dataCons) =
-  TypeDeclaration (fromPrimTyCon tyCon) (fromPrimDataCon <$> dataCons)
+  TypeDeclaration (fromPrimTyDef tyCon) (fromPrimDataCon <$> dataCons)
 
 data DataConstructor
   = DataConstructor

--- a/library/Amy/Renamer/AST.hs
+++ b/library/Amy/Renamer/AST.hs
@@ -81,10 +81,10 @@ data TyConDefinition
   , tyConDefinitionId :: !Int
   , tyConDefinitionArgs :: ![TyVarInfo]
   , tyConDefinitionLocation :: !(Maybe SourceSpan)
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Ord)
 
 tyConDefinitionToInfo :: TyConDefinition -> TyConInfo
-tyConDefinitionToInfo (TyConDefinition name' id' args span') = TyConInfo name' id' (TyVarArg <$> args) span'
+tyConDefinitionToInfo tyDef@(TyConDefinition name' id' args span') = TyConInfo name' id' (TyVarArg <$> args) tyDef span'
 
 fromPrimTyDef :: PrimTyCon -> TyConDefinition
 fromPrimTyDef (PrimTyCon name id') = TyConDefinition name id' [] Nothing
@@ -193,11 +193,12 @@ data TyConInfo
   { tyConInfoName :: !Text
   , tyConInfoId :: !Int
   , tyConInfoArgs :: ![TyArg]
+  , tyConDefinition :: !TyConDefinition
   , tyConInfoLocation :: !(Maybe SourceSpan)
   } deriving (Show, Eq, Ord)
 
 fromPrimTyCon :: PrimTyCon -> TyConInfo
-fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' [] Nothing
+fromPrimTyCon = tyConDefinitionToInfo . fromPrimTyDef
 
 data TyVarInfo
   = TyVarInfo

--- a/library/Amy/Renamer/AST.hs
+++ b/library/Amy/Renamer/AST.hs
@@ -8,6 +8,7 @@ module Amy.Renamer.AST
   , fromPrimTypeDef
   , DataConstructor(..)
   , DataConInfo(..)
+  , DataConArg(..)
   , Expr(..)
   , Var(..)
   , If(..)
@@ -69,22 +70,28 @@ data Extern
 data TypeDeclaration
   = TypeDeclaration
   { typeDeclarationTypeName :: !TyConInfo
+  , typeDeclarationTyVars :: ![TyVarInfo]
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq)
 
 fromPrimTypeDef :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDef (PrimTypeDefinition tyCon dataCons) =
-  TypeDeclaration (fromPrimTyCon tyCon) (fromPrimDataCon <$> dataCons)
+  TypeDeclaration (fromPrimTyCon tyCon) [] (fromPrimDataCon <$> dataCons)
 
 data DataConstructor
   = DataConstructor
   { dataConstructorName :: !(Located Text)
   , dataConstructorId :: !Int
-  , dataConstructorArgument :: !(Maybe TyConInfo)
+  , dataConstructorArgument :: !(Maybe DataConArg)
   , dataConstructorType :: !TyConInfo
   , dataConstructorSpan :: !ConstructorSpan
   , dataConstructorIndex :: !ConstructorIndex
   } deriving (Show, Eq)
+
+data DataConArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
+  deriving (Show, Eq)
 
 fromPrimDataCon :: PrimDataCon -> DataConstructor
 fromPrimDataCon (PrimDataCon name id' ty span' index) =

--- a/library/Amy/Renamer/AST.hs
+++ b/library/Amy/Renamer/AST.hs
@@ -8,7 +8,6 @@ module Amy.Renamer.AST
   , fromPrimTypeDef
   , DataConstructor(..)
   , DataConInfo(..)
-  , DataConArg(..)
   , Expr(..)
   , Var(..)
   , If(..)
@@ -23,6 +22,7 @@ module Amy.Renamer.AST
   , Type(..)
   , TyConInfo(..)
   , TyVarInfo(..)
+  , TyArg(..)
   , Scheme(..)
 
     -- Re-export
@@ -70,28 +70,22 @@ data Extern
 data TypeDeclaration
   = TypeDeclaration
   { typeDeclarationTypeName :: !TyConInfo
-  , typeDeclarationTyVars :: ![TyVarInfo]
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq)
 
 fromPrimTypeDef :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDef (PrimTypeDefinition tyCon dataCons) =
-  TypeDeclaration (fromPrimTyCon tyCon) [] (fromPrimDataCon <$> dataCons)
+  TypeDeclaration (fromPrimTyCon tyCon) (fromPrimDataCon <$> dataCons)
 
 data DataConstructor
   = DataConstructor
   { dataConstructorName :: !(Located Text)
   , dataConstructorId :: !Int
-  , dataConstructorArgument :: !(Maybe DataConArg)
+  , dataConstructorArgument :: !(Maybe TyArg)
   , dataConstructorType :: !TyConInfo
   , dataConstructorSpan :: !ConstructorSpan
   , dataConstructorIndex :: !ConstructorIndex
   } deriving (Show, Eq)
-
-data DataConArg
-  = TyConArg !TyConInfo
-  | TyVarArg !TyVarInfo
-  deriving (Show, Eq)
 
 fromPrimDataCon :: PrimDataCon -> DataConstructor
 fromPrimDataCon (PrimDataCon name id' ty span' index) =
@@ -180,20 +174,26 @@ infixr 0 `TyFun`
 
 data TyConInfo
   = TyConInfo
-  { tyConInfoText :: !Text
-  , tyConInfoLocation :: !(Maybe SourceSpan)
+  { tyConInfoName :: !Text
   , tyConInfoId :: !Int
+  , tyConInfoArgs :: ![TyArg]
+  , tyConInfoLocation :: !(Maybe SourceSpan)
   } deriving (Show, Eq, Ord)
 
 fromPrimTyCon :: PrimTyCon -> TyConInfo
-fromPrimTyCon (PrimTyCon name id') = TyConInfo name Nothing id'
+fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' [] Nothing
 
 data TyVarInfo
   = TyVarInfo
   { tyVarInfoName :: !Text
   , tyVarInfoId :: !Int
   , tyVarInfoLocation :: !SourceSpan
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Ord)
+
+data TyArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
+  deriving (Show, Eq, Ord)
 
 data Scheme
   = Forall ![TyVarInfo] Type

--- a/library/Amy/Renamer/Monad.hs
+++ b/library/Amy/Renamer/Monad.hs
@@ -199,7 +199,7 @@ lookupTypeConstructorInScopeOrError (S.TyConInfo name args span') = do
   mTyCon <- lookupTypeConstructorInScope name
   case mTyCon of
     Nothing -> pure $ Failure [UnknownTypeConstructor (Located span' name)]
-    Just (R.TyConInfo name' id' _ span'') -> do
+    Just (R.TyConInfo name' id' _ tyDef span'') -> do
       args' <- for args $ \arg ->
         case arg of
           S.TyConArg info' -> fmap R.TyConArg <$> lookupTypeConstructorInScopeOrError info'
@@ -209,6 +209,7 @@ lookupTypeConstructorInScopeOrError (S.TyConInfo name args span') = do
         <$> pure name'
         <*> pure id'
         <*> sequenceA args'
+        <*> pure tyDef
         <*> pure span''
 
 addTypeDeclarationToScope :: R.TypeDeclaration -> Renamer R.TypeDeclaration

--- a/library/Amy/Renamer/Monad.hs
+++ b/library/Amy/Renamer/Monad.hs
@@ -134,7 +134,7 @@ lookupValueInScopeOrError name@(Located span' name') =
 
 addDataConstructorToScope
   :: Located Text
-  -> Maybe (Validation [Error] R.TyConInfo)
+  -> Maybe (Validation [Error] R.DataConArg)
   -> Validation [Error] R.TyConInfo
   -> ConstructorSpan
   -> ConstructorIndex

--- a/library/Amy/Renamer/Renamer.hs
+++ b/library/Amy/Renamer/Renamer.hs
@@ -51,7 +51,6 @@ renameTypeDeclaration (S.TypeDeclaration tyDef constructors) = do
     span' = ConstructorSpan $ length constructors
     indexes = ConstructorIndex <$> [0..]
 
-  -- Check for duplicate type variables
   liftValidation tyDef' $ \tyDef'' -> do
     let
       tyVars = R.tyConDefinitionArgs tyDef''

--- a/library/Amy/Renamer/Renamer.hs
+++ b/library/Amy/Renamer/Renamer.hs
@@ -4,8 +4,7 @@ module Amy.Renamer.Renamer
   ( rename
   ) where
 
-import Data.Either (rights)
-import Data.List (find, foldl')
+import Data.List (find)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -45,26 +44,17 @@ rename' (S.Module declarations) = do
     <*> pure maxId
 
 renameTypeDeclaration :: S.TypeDeclaration -> Renamer (Validation [Error] R.TypeDeclaration)
-renameTypeDeclaration (S.TypeDeclaration tyName tyVars constructors) = do
+renameTypeDeclaration (S.TypeDeclaration tyName constructors) = do
   -- Rename type name
   tyName' <- addTypeConstructorToScope tyName
   let
     span' = ConstructorSpan $ length constructors
     indexes = ConstructorIndex <$> [0..]
+    tyVars = R.tyConInfoArgs <$> tyName'
+    getTyVarArg (R.TyConArg _) = Nothing
+    getTyVarArg (R.TyVarArg info) = Just info
 
-  -- Rename type variables and ensure they are unique
-  tyVars' <- for tyVars $ \(S.TyVarInfo (Located s v)) -> do
-    id' <- freshId
-    pure $ R.TyVarInfo v id' s
-  let
-    checkTyVarDuplicates :: [Validation [Error] R.TyVarInfo] -> R.TyVarInfo -> [Validation [Error] R.TyVarInfo]
-    checkTyVarDuplicates previousVars var =
-      let successes = rights $ toEither <$> previousVars
-      in case find ((== R.tyVarInfoName var) . R.tyVarInfoName) successes of
-        Nothing -> previousVars ++ [Success var]
-        Just prev -> previousVars ++ [Failure [DuplicateTypeVariable var prev]]
-    tyVars'' :: [Validation [Error] R.TyVarInfo]
-    tyVars'' = foldl' checkTyVarDuplicates [] tyVars'
+  -- TODO: Check for duplicate type variables
 
   -- Rename data constructors
   constructors' <- for (zip indexes constructors) $ \(i, S.DataConstructor name mArgTy) -> do
@@ -72,14 +62,14 @@ renameTypeDeclaration (S.TypeDeclaration tyName tyVars constructors) = do
       case argTy of
         S.TyConArg tyCon -> fmap R.TyConArg <$> lookupTypeConstructorInScopeOrError tyCon
         S.TyVarArg (S.TyVarInfo tyVar) ->
-          case find ((== locatedValue tyVar) . R.tyVarInfoName) tyVars' of
-            Just var -> pure $ Success $ R.TyVarArg var
-            Nothing -> pure $ Failure [UnknownTypeVariable tyVar]
+          pure $ tyVars `bindValidation` \tyVars' ->
+            case find ((== locatedValue tyVar) . R.tyVarInfoName) (mapMaybe getTyVarArg tyVars') of
+              Just var -> Success $ R.TyVarArg var
+              Nothing -> Failure [UnknownTypeVariable tyVar]
     addDataConstructorToScope name mArgTy' tyName' span' i
   traverse addTypeDeclarationToScope
     $ R.TypeDeclaration
     <$> tyName'
-    <*> sequenceA tyVars''
     <*> sequenceA constructors'
 
 renameExtern :: S.Extern -> Renamer (Validation [Error] R.Extern)

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -12,7 +12,6 @@ module Amy.Syntax.AST
   , Extern(..)
   , TypeDeclaration(..)
   , DataConstructor(..)
-  , DataConArg(..)
   , Expr(..)
   , Var(..)
   , If(..)
@@ -28,6 +27,7 @@ module Amy.Syntax.AST
   , Type(..)
   , TyConInfo(..)
   , TyVarInfo(..)
+  , TyArg(..)
   , Scheme(..)
 
     -- Re-export
@@ -97,20 +97,14 @@ data Extern
 data TypeDeclaration
   = TypeDeclaration
   { typeDeclarationTypeName :: !TyConInfo
-  , typeDeclarationTyVars :: ![TyVarInfo]
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq)
 
 data DataConstructor
   = DataConstructor
   { dataConstructorName :: !(Located Text)
-  , dataConstructorArgument :: !(Maybe DataConArg)
+  , dataConstructorArgument :: !(Maybe TyArg)
   } deriving (Show, Eq)
-
-data DataConArg
-  = TyConArg !TyConInfo
-  | TyVarArg !TyVarInfo
-  deriving (Show, Eq)
 
 data Expr
   = ELit !(Located Literal)
@@ -193,7 +187,16 @@ data Type
 
 infixr 0 `TyFun`
 
-newtype TyConInfo = TyConInfo { unTyConInfo :: Located Text }
+data TyConInfo
+  = TyConInfo
+  { tyConInfoName :: !Text
+  , tyConInfoArgs :: ![TyArg]
+  , tyConInfoLocation :: !SourceSpan
+  } deriving (Show, Eq)
+
+data TyArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
   deriving (Show, Eq)
 
 newtype TyVarInfo = TyVarInfo { unTyVarInfo :: Located Text }

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -12,6 +12,7 @@ module Amy.Syntax.AST
   , Extern(..)
   , TypeDeclaration(..)
   , DataConstructor(..)
+  , DataConArg(..)
   , Expr(..)
   , Var(..)
   , If(..)
@@ -96,14 +97,20 @@ data Extern
 data TypeDeclaration
   = TypeDeclaration
   { typeDeclarationTypeName :: !TyConInfo
+  , typeDeclarationTyVars :: ![TyVarInfo]
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq)
 
 data DataConstructor
   = DataConstructor
   { dataConstructorName :: !(Located Text)
-  , dataConstructorArgument :: !(Maybe TyConInfo)
+  , dataConstructorArgument :: !(Maybe DataConArg)
   } deriving (Show, Eq)
+
+data DataConArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
+  deriving (Show, Eq)
 
 data Expr
   = ELit !(Located Literal)

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -11,6 +11,7 @@ module Amy.Syntax.AST
   , BindingType(..)
   , Extern(..)
   , TypeDeclaration(..)
+  , TyConDefinition(..)
   , DataConstructor(..)
   , Expr(..)
   , Var(..)
@@ -96,8 +97,15 @@ data Extern
 
 data TypeDeclaration
   = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConInfo
+  { typeDeclarationTypeName :: !TyConDefinition
   , typeDeclarationConstructors :: ![DataConstructor]
+  } deriving (Show, Eq)
+
+data TyConDefinition
+  = TyConDefinition
+  { tyConDefinitionName :: !Text
+  , tyConDefinitionArgs :: ![TyVarInfo]
+  , tyConDefinitionLocation :: !SourceSpan
   } deriving (Show, Eq)
 
 data DataConstructor

--- a/library/Amy/Syntax/Parser.hs
+++ b/library/Amy/Syntax/Parser.hs
@@ -103,6 +103,7 @@ binding = do
 typeDeclaration :: AmyParser TypeDeclaration
 typeDeclaration = do
   tyName <- tyConInfo
+  tyVars <- many $ tyVarInfo <* spaceConsumer
   equals' <- optional $ equals <* spaceConsumerNewlines
   constructors <-
     case equals' of
@@ -111,13 +112,14 @@ typeDeclaration = do
   pure
     TypeDeclaration
     { typeDeclarationTypeName = tyName
+    , typeDeclarationTyVars = tyVars
     , typeDeclarationConstructors = constructors
     }
 
 dataConstructor :: AmyParser DataConstructor
 dataConstructor = do
   dataCon <- dataConstructorName'
-  mArg <- optional tyConInfo
+  mArg <- optional $ (TyConArg <$> tyConInfo) <|> (TyVarArg <$> tyVarInfo)
   pure
     DataConstructor
     { dataConstructorName = dataCon

--- a/library/Amy/Syntax/Parser.hs
+++ b/library/Amy/Syntax/Parser.hs
@@ -113,7 +113,7 @@ binding = do
 
 typeDeclaration :: AmyParser TypeDeclaration
 typeDeclaration = do
-  tyName <- tyConInfo True
+  tyName <- tyConDefinition
   equals' <- optional $ equals <* spaceConsumerNewlines
   constructors <-
     case equals' of
@@ -123,6 +123,17 @@ typeDeclaration = do
     TypeDeclaration
     { typeDeclarationTypeName = tyName
     , typeDeclarationConstructors = constructors
+    }
+
+tyConDefinition :: AmyParser TyConDefinition
+tyConDefinition = do
+  Located span' name <- typeIdentifier
+  args <- many tyVarInfo
+  pure
+    TyConDefinition
+    { tyConDefinitionName = name
+    , tyConDefinitionArgs = args
+    , tyConDefinitionLocation = span'
     }
 
 dataConstructor :: AmyParser DataConstructor

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -36,10 +36,15 @@ prettyDeclaration (DeclBindingType bindingTy) = prettyBindingType' bindingTy
 prettyDeclaration (DeclExtern (Extern (Located _ name) ty)) =
   prettyExtern (pretty name) (mkPrettyType ty)
 prettyDeclaration (DeclType (TypeDeclaration info cons)) =
-  prettyTypeDeclaration (prettyTyConInfo info) (prettyConstructor <$> cons)
+  prettyTypeDeclaration (prettyTyConDefinition info) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor (Located _ conName) mArg) =
     prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
+
+prettyTyConDefinition :: TyConDefinition -> Doc ann
+prettyTyConDefinition (TyConDefinition name args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else space <> sep (prettyTyVarInfo <$> args)
 
 prettyTyArg :: TyArg -> Doc ann
 prettyTyArg (TyConArg info) = prettyTyConInfo info

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -19,7 +19,7 @@ mkPrettyType (TyFun ty1 ty2) = PTyFun (mkPrettyType ty1) (mkPrettyType ty2)
 prettyTyConInfo :: TyConInfo -> Doc ann
 prettyTyConInfo (TyConInfo name args _) = pretty name <> args'
  where
-  args' = if null args then mempty else sep (prettyTyArg <$> args)
+  args' = if null args then mempty else space <> sep (prettyTyArg <$> args)
 
 prettyTyVarInfo :: TyVarInfo -> Doc ann
 prettyTyVarInfo (TyVarInfo (Located _ name)) = pretty name

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -12,9 +12,15 @@ import Amy.Pretty
 import Amy.Syntax.AST
 
 mkPrettyType :: Type -> PrettyType ann
-mkPrettyType (TyCon (TyConInfo (Located _ var))) = PTyDoc $ pretty var
-mkPrettyType (TyVar (TyVarInfo (Located _ var))) = PTyDoc $ pretty var
+mkPrettyType (TyCon info) = PTyDoc $ prettyTyConInfo info
+mkPrettyType (TyVar info) = PTyDoc $ prettyTyVarInfo info
 mkPrettyType (TyFun ty1 ty2) = PTyFun (mkPrettyType ty1) (mkPrettyType ty2)
+
+prettyTyConInfo :: TyConInfo -> Doc ann
+prettyTyConInfo (TyConInfo (Located _ name)) = pretty name
+
+prettyTyVarInfo :: TyVarInfo -> Doc ann
+prettyTyVarInfo (TyVarInfo (Located _ name)) = pretty name
 
 mkPrettyScheme :: Scheme -> PrettyScheme ann
 mkPrettyScheme (Forall vars ty) = PForall (pretty . locatedValue . unTyVarInfo <$> vars) (mkPrettyType ty)
@@ -27,11 +33,15 @@ prettyDeclaration (DeclBinding binding) = prettyBinding' binding
 prettyDeclaration (DeclBindingType bindingTy) = prettyBindingType' bindingTy
 prettyDeclaration (DeclExtern (Extern (Located _ name) ty)) =
   prettyExtern (pretty name) (mkPrettyType ty)
-prettyDeclaration (DeclType (TypeDeclaration (TyConInfo (Located _ tyName)) cons)) =
-  prettyTypeDeclaration (pretty tyName) (prettyConstructor <$> cons)
+prettyDeclaration (DeclType (TypeDeclaration (TyConInfo (Located _ tyName)) tyVars cons)) =
+  prettyTypeDeclaration (pretty tyName) (prettyTyVarInfo <$> tyVars) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor (Located _ conName) mArg) =
-    prettyDataConstructor (pretty conName) (pretty . locatedValue . unTyConInfo <$> mArg)
+    prettyDataConstructor (pretty conName) (prettyDataConArg <$> mArg)
+
+prettyDataConArg :: DataConArg -> Doc ann
+prettyDataConArg (TyConArg info) = prettyTyConInfo info
+prettyDataConArg (TyVarArg info) = prettyTyVarInfo info
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding (Located _ name) args body) =

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -17,7 +17,9 @@ mkPrettyType (TyVar info) = PTyDoc $ prettyTyVarInfo info
 mkPrettyType (TyFun ty1 ty2) = PTyFun (mkPrettyType ty1) (mkPrettyType ty2)
 
 prettyTyConInfo :: TyConInfo -> Doc ann
-prettyTyConInfo (TyConInfo (Located _ name)) = pretty name
+prettyTyConInfo (TyConInfo name args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else sep (prettyTyArg <$> args)
 
 prettyTyVarInfo :: TyVarInfo -> Doc ann
 prettyTyVarInfo (TyVarInfo (Located _ name)) = pretty name
@@ -33,15 +35,15 @@ prettyDeclaration (DeclBinding binding) = prettyBinding' binding
 prettyDeclaration (DeclBindingType bindingTy) = prettyBindingType' bindingTy
 prettyDeclaration (DeclExtern (Extern (Located _ name) ty)) =
   prettyExtern (pretty name) (mkPrettyType ty)
-prettyDeclaration (DeclType (TypeDeclaration (TyConInfo (Located _ tyName)) tyVars cons)) =
-  prettyTypeDeclaration (pretty tyName) (prettyTyVarInfo <$> tyVars) (prettyConstructor <$> cons)
+prettyDeclaration (DeclType (TypeDeclaration info cons)) =
+  prettyTypeDeclaration (prettyTyConInfo info) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor (Located _ conName) mArg) =
-    prettyDataConstructor (pretty conName) (prettyDataConArg <$> mArg)
+    prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
 
-prettyDataConArg :: DataConArg -> Doc ann
-prettyDataConArg (TyConArg info) = prettyTyConInfo info
-prettyDataConArg (TyVarArg info) = prettyTyVarInfo info
+prettyTyArg :: TyArg -> Doc ann
+prettyTyArg (TyConArg info) = prettyTyConInfo info
+prettyTyArg (TyVarArg info) = prettyTyVarInfo info
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding (Located _ name) args body) =

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -7,6 +7,7 @@ module Amy.TypeCheck.AST
   , Binding(..)
   , Extern(..)
   , TypeDeclaration(..)
+  , TyConDefinition(..)
   , fromPrimTypeDef
   , DataConstructor(..)
   , fromPrimDataCon
@@ -79,13 +80,24 @@ data Extern
 
 data TypeDeclaration
   = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConInfo
+  { typeDeclarationTypeName :: !TyConDefinition
   , typeDeclarationConstructors :: ![DataConstructor]
   } deriving (Show, Eq, Ord)
 
+data TyConDefinition
+  = TyConDefinition
+  { tyConDefinitionName :: !Text
+  , tyConDefinitionId :: !Int
+  , tyConDefinitionArgs :: ![TyVarInfo]
+  , tyConDefinitionKind :: !Kind
+  } deriving (Show, Eq, Ord)
+
+definitionFromPrimTyCon :: PrimTyCon -> TyConDefinition
+definitionFromPrimTyCon (PrimTyCon name id') = TyConDefinition name id' [] KStar
+
 fromPrimTypeDef :: PrimTypeDefinition -> TypeDeclaration
 fromPrimTypeDef (PrimTypeDefinition tyCon dataCons) =
-  TypeDeclaration (fromPrimTyCon tyCon) (fromPrimDataCon <$> dataCons)
+  TypeDeclaration (definitionFromPrimTyCon tyCon) (fromPrimDataCon <$> dataCons)
 
 data DataConstructor
   = DataConstructor

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -29,6 +29,7 @@ module Amy.TypeCheck.AST
   , fromPrimTyCon
   , TyVarInfo(..)
   , TyVarGenerated(..)
+  , TyArg(..)
   , typeKind
   , Scheme(..)
   , Typed(..)
@@ -90,7 +91,7 @@ data DataConstructor
   = DataConstructor
   { dataConstructorName :: !Text
   , dataConstructorId :: !Int
-  , dataConstructorArgument :: !(Maybe TyConInfo)
+  , dataConstructorArgument :: !(Maybe TyArg)
   , dataConstructorType :: !TyConInfo
   , dataConstructorSpan :: !ConstructorSpan
   , dataConstructorIndex :: !ConstructorIndex
@@ -205,13 +206,14 @@ infixr 0 `TyFun`
 
 data TyConInfo
   = TyConInfo
-  { tyConInfoText :: !Text
+  { tyConInfoName :: !Text
   , tyConInfoId :: !Int
+  , tyConInfoArgs :: ![TyArg]
   , tyConInfoKind :: !Kind
   } deriving (Show, Eq, Ord)
 
 fromPrimTyCon :: PrimTyCon -> TyConInfo
-fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' KStar
+fromPrimTyCon (PrimTyCon name id') = TyConInfo name id' [] KStar
 
 data TyVarInfo
   = TyVarInfo
@@ -224,6 +226,11 @@ data TyVarInfo
 data TyVarGenerated
   = TyVarGenerated
   | TyVarNotGenerated
+  deriving (Show, Eq, Ord)
+
+data TyArg
+  = TyConArg !TyConInfo
+  | TyVarArg !TyVarInfo
   deriving (Show, Eq, Ord)
 
 typeKind :: Type -> Kind

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -234,7 +234,10 @@ data TyArg
   deriving (Show, Eq, Ord)
 
 typeKind :: Type -> Kind
-typeKind (TyCon info) = tyConInfoKind info
+typeKind (TyCon info) =
+  case tyConInfoKind info of
+    KStar -> KStar
+    KFun k _ -> k
 typeKind (TyVar var) = tyVarInfoKind var
 typeKind (TyFun _ _) = KStar
 

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -163,7 +163,7 @@ convertExtern :: R.Extern -> T.Extern
 convertExtern (R.Extern (Located _ name) ty) = T.Extern (convertIdent name) (convertType ty)
 
 convertTypeDeclaration :: R.TypeDeclaration -> T.TypeDeclaration
-convertTypeDeclaration (R.TypeDeclaration tyName cons) =
+convertTypeDeclaration (R.TypeDeclaration tyName _ cons) =
   T.TypeDeclaration (convertTyConInfo tyName) (convertDataConstructor <$> cons)
 
 convertDataConstructor :: R.DataConstructor -> T.DataConstructor
@@ -171,11 +171,15 @@ convertDataConstructor (R.DataConstructor (Located _ conName) id' mTyArg tyName 
   T.DataConstructor
   { T.dataConstructorName = conName
   , T.dataConstructorId = id'
-  , T.dataConstructorArgument = convertTyConInfo <$> mTyArg
+  , T.dataConstructorArgument = convertDataConArg <$> mTyArg
   , T.dataConstructorType = convertTyConInfo tyName
   , T.dataConstructorSpan = span'
   , T.dataConstructorIndex = index
   }
+
+convertDataConArg :: R.DataConArg -> T.TyConInfo
+convertDataConArg (R.TyConArg info) = convertTyConInfo info
+convertDataConArg (R.TyVarArg info) = error $ "Can't handle data constructor tyvar args yet " ++ show info
 
 convertDataConInfo :: R.DataConInfo -> T.DataConInfo
 convertDataConInfo (R.DataConInfo tyDecl dataCon) =

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -486,7 +486,7 @@ substituteType subst (T.TyCon con) = T.TyCon $ substituteTyConInfo subst con
 substituteType subst (t1 `T.TyFun` t2) = substituteType subst t1 `T.TyFun` substituteType subst t2
 
 substituteTyConInfo :: Subst -> T.TyConInfo -> T.TyConInfo
-substituteTyConInfo subst (T.TyConInfo name id' args kind) = T.TyConInfo name id' (substituteTyArg subst <$> args) kind
+substituteTyConInfo subst (T.TyConInfo name id' args tyDef) = T.TyConInfo name id' (substituteTyArg subst <$> args) tyDef
 
 substituteTyArg :: Subst -> T.TyArg -> T.TyArg
 substituteTyArg subst (T.TyConArg con) = T.TyConArg $ substituteTyConInfo subst con
@@ -609,12 +609,7 @@ convertTyConDefinition (R.TyConDefinition name' id' args _) = T.TyConDefinition 
   kind = foldr1 KFun $ const KStar <$> [0..length args]
 
 convertTyConInfo :: R.TyConInfo -> T.TyConInfo
-convertTyConInfo (R.TyConInfo name' id' args _) = T.TyConInfo name' id' (convertTyArg <$> args) kind
- where
-  -- Our kind inference is really simple. We don't have higher-kinded types so
-  -- we just count the number of type variables and make a * for each one, plus
-  -- a * for the type constructor. Easy!
-  kind = foldr1 KFun $ const KStar <$> [0..length args]
+convertTyConInfo (R.TyConInfo name' id' args tyDef _) = T.TyConInfo name' id' (convertTyArg <$> args) (convertTyConDefinition tyDef)
 
 convertTyVarInfo :: R.TyVarInfo -> T.TyVarInfo
 convertTyVarInfo (R.TyVarInfo name' id' _) = T.TyVarInfo name' id' KStar TyVarNotGenerated

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -426,7 +426,22 @@ unifies (T.TyFun t1 t2) (T.TyFun t3 t4) = do
   su1 <- unifies t1 t3
   su2 <- unifies (substituteType su1 t2) (substituteType su1 t4)
   pure (su2 `composeSubst` su1)
+unifies t1@(T.TyCon (T.TyConInfo _ id1 args1 _)) t2@(T.TyCon (T.TyConInfo _ id2 args2 _)) =
+  if id1 /= id2 || length args1 /= length args2
+  then throwError $ UnificationFail t1 t2
+  else unifyMany (argToType <$> args1) (argToType <$> args2)
+ where
+  argToType (T.TyConArg info) = T.TyCon info
+  argToType (T.TyVarArg info) = T.TyVar info
 unifies t1 t2 = throwError $ UnificationFail t1 t2
+
+unifyMany :: [T.Type] -> [T.Type] -> Solve Subst
+unifyMany [] [] = return emptySubst
+unifyMany (t1 : ts1) (t2 : ts2) = do
+  su1 <- unifies t1 t2
+  su2 <- unifyMany (substituteType su1 <$> ts1) (substituteType su1 <$> ts2)
+  return (su2 `composeSubst` su1)
+unifyMany t1 t2 = error $ "unifyMany lists different length " ++ show (t1, t2)
 
 bind ::  T.TyVarInfo -> T.Type -> Solve Subst
 bind a t

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -445,7 +445,8 @@ unifyMany t1 t2 = error $ "unifyMany lists different length " ++ show (t1, t2)
 bind ::  T.TyVarInfo -> T.Type -> Solve Subst
 bind a t
   | t == T.TyVar a = return emptySubst
-  -- | T.tyVarInfoKind a /= typeKind t = throwError $ KindMismatch a t -- TODO: Check kinds
+  -- TODO: Check kinds
+  -- | T.tyVarInfoKind a /= typeKind t = throwError $ KindMismatch a t
   | occursCheck a t = throwError $ InfiniteType a t
   | otherwise = return (singletonSubst a t)
 

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -6,7 +6,6 @@ module Amy.TypeCheck.Inference
   ( inferModule
   , inferTopLevel
   , TyEnv
-  , emptyEnv
   ) where
 
 import Control.Monad.Except
@@ -40,9 +39,6 @@ data TyEnv
   { identTypes :: Map T.Ident T.Scheme
   } deriving (Show, Eq)
 
-emptyEnv :: TyEnv
-emptyEnv = TyEnv Map.empty
-
 extendEnvIdent :: TyEnv -> (T.Ident, T.Scheme) -> TyEnv
 extendEnvIdent env (x, s) =
   env
@@ -52,17 +48,8 @@ extendEnvIdent env (x, s) =
 extendEnvIdentList :: TyEnv -> [(T.Ident, T.Scheme)] -> TyEnv
 extendEnvIdentList = foldl' extendEnvIdent
 
--- removeEnv :: TyEnv -> Name -> TyEnv
--- removeEnv (TyEnv env) var = TyEnv (Map.delete var env)
-
 lookupEnvIdent :: T.Ident -> TyEnv -> Maybe T.Scheme
 lookupEnvIdent key = Map.lookup key . identTypes
-
--- mergeEnv :: TyEnv -> TyEnv -> TyEnv
--- mergeEnv (TyEnv a) (TyEnv b) = TyEnv (Map.union a b)
-
--- mergeEnvs :: [TyEnv] -> TyEnv
--- mergeEnvs = foldl' mergeEnv emptyEnv
 
 --
 -- Inference Monad

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -202,7 +202,7 @@ inferTopLevel maxId env bindings = do
           (T.Forall _ ty) = T.bindingType binding
           (scheme', letterSubst) = normalize ty
           binding' = binding { T.bindingType = scheme' }
-          subst' = composeSubst subst letterSubst
+          subst' = composeSubst letterSubst subst
         in substituteBinding subst' binding'
   pure (bindings'', maxId')
 

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -445,8 +445,7 @@ unifyMany t1 t2 = error $ "unifyMany lists different length " ++ show (t1, t2)
 bind ::  T.TyVarInfo -> T.Type -> Solve Subst
 bind a t
   | t == T.TyVar a = return emptySubst
-  -- TODO: Check kinds
-  -- | T.tyVarInfoKind a /= typeKind t = throwError $ KindMismatch a t
+  | T.tyVarInfoKind a /= typeKind t = throwError $ KindMismatch a t
   | occursCheck a t = throwError $ InfiniteType a t
   | otherwise = return (singletonSubst a t)
 

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -150,7 +150,7 @@ convertExtern :: R.Extern -> T.Extern
 convertExtern (R.Extern (Located _ name) ty) = T.Extern (convertIdent name) (convertType ty)
 
 convertTypeDeclaration :: R.TypeDeclaration -> T.TypeDeclaration
-convertTypeDeclaration (R.TypeDeclaration tyName _ cons) =
+convertTypeDeclaration (R.TypeDeclaration tyName cons) =
   T.TypeDeclaration (convertTyConInfo tyName) (convertDataConstructor <$> cons)
 
 convertDataConstructor :: R.DataConstructor -> T.DataConstructor
@@ -158,15 +158,15 @@ convertDataConstructor (R.DataConstructor (Located _ conName) id' mTyArg tyName 
   T.DataConstructor
   { T.dataConstructorName = conName
   , T.dataConstructorId = id'
-  , T.dataConstructorArgument = convertDataConArg <$> mTyArg
+  , T.dataConstructorArgument = convertTyArg <$> mTyArg
   , T.dataConstructorType = convertTyConInfo tyName
   , T.dataConstructorSpan = span'
   , T.dataConstructorIndex = index
   }
 
-convertDataConArg :: R.DataConArg -> T.TyConInfo
-convertDataConArg (R.TyConArg info) = convertTyConInfo info
-convertDataConArg (R.TyVarArg info) = error $ "Can't handle data constructor tyvar args yet " ++ show info
+convertTyArg :: R.TyArg -> T.TyConInfo
+convertTyArg (R.TyConArg info) = convertTyConInfo info
+convertTyArg (R.TyVarArg info) = error $ "Can't handle data constructor tyvar args yet " ++ show info
 
 convertDataConInfo :: R.DataConInfo -> T.DataConInfo
 convertDataConInfo (R.DataConInfo tyDecl dataCon) =
@@ -543,7 +543,8 @@ convertType (R.TyVar info) = T.TyVar (convertTyVarInfo info)
 convertType (R.TyFun ty1 ty2) = T.TyFun (convertType ty1) (convertType ty2)
 
 convertTyConInfo :: R.TyConInfo -> T.TyConInfo
-convertTyConInfo (R.TyConInfo name' _ id') = T.TyConInfo name' id' KStar
+convertTyConInfo (R.TyConInfo name' id' [] _) = T.TyConInfo name' id' KStar
+convertTyConInfo _ = error "Can't handle type arguments yet"
 
 convertTyVarInfo :: R.TyVarInfo -> T.TyVarInfo
 convertTyVarInfo (R.TyVarInfo name' id' _) = T.TyVarInfo name' id' KStar TyVarNotGenerated

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -426,10 +426,9 @@ unifies (T.TyFun t1 t2) (T.TyFun t3 t4) = do
   su1 <- unifies t1 t3
   su2 <- unifies (substituteType su1 t2) (substituteType su1 t4)
   pure (su2 `composeSubst` su1)
-unifies t1@(T.TyCon (T.TyConInfo _ id1 args1 _)) t2@(T.TyCon (T.TyConInfo _ id2 args2 _)) =
-  if id1 /= id2 || length args1 /= length args2
-  then throwError $ UnificationFail t1 t2
-  else unifyMany (argToType <$> args1) (argToType <$> args2)
+unifies (T.TyCon (T.TyConInfo _ id1 args1 _)) (T.TyCon (T.TyConInfo _ id2 args2 _))
+  | id1 == id2 && length args1 == length args2 =
+    unifyMany (argToType <$> args1) (argToType <$> args2)
  where
   argToType (T.TyConArg info) = T.TyCon info
   argToType (T.TyVarArg info) = T.TyVar info

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -43,10 +43,15 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConDefinition tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
+
+prettyTyConDefinition :: TyConDefinition -> Doc ann
+prettyTyConDefinition (TyConDefinition name _ args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else space <> sep (prettyTyVarInfo <$> args)
 
 prettyTyArg :: TyArg -> Doc ann
 prettyTyArg (TyConArg info) = prettyTyConInfo info

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -36,7 +36,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) [] (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -1,6 +1,11 @@
 module Amy.TypeCheck.Pretty
   ( prettyModule
   , prettyExpr
+
+  , prettyScheme
+  , mkPrettyScheme
+  , prettyType
+  , mkPrettyType
   ) where
 
 import Data.Foldable (toList)
@@ -15,7 +20,9 @@ mkPrettyType (TyVar name) = PTyDoc $ prettyTyVarInfo name
 mkPrettyType (TyFun ty1 ty2) = PTyFun (mkPrettyType ty1) (mkPrettyType ty2)
 
 prettyTyConInfo :: TyConInfo -> Doc ann
-prettyTyConInfo (TyConInfo name _ _) = pretty name
+prettyTyConInfo (TyConInfo name _ args _) = pretty name <> args'
+ where
+  args' = if null args then mempty else space <> sep (prettyTyArg <$> args)
 
 prettyTyVarInfo :: TyVarInfo -> Doc ann
 prettyTyVarInfo (TyVarInfo name _ _ _) = pretty name
@@ -39,7 +46,11 @@ prettyTypeDeclaration' (TypeDeclaration tyName cons) =
    prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
-    prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)
+    prettyDataConstructor (pretty conName) (prettyTyArg <$> mArg)
+
+prettyTyArg :: TyArg -> Doc ann
+prettyTyArg (TyConArg info) = prettyTyConInfo info
+prettyTyArg (TyVarArg info) = prettyTyVarInfo info
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding ident scheme args _ body) =

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -36,7 +36,7 @@ prettyExtern' (Extern name ty) =
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
-   prettyTypeDeclaration (prettyTyConInfo tyName) (prettyConstructor <$> cons)
+   prettyTypeDeclaration (prettyTyConInfo tyName) [] (prettyConstructor <$> cons)
  where
   prettyConstructor (DataConstructor conName _ mArg _ _ _) =
     prettyDataConstructor (pretty conName) (prettyTyConInfo <$> mArg)

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -38,7 +38,7 @@ match'
 match' vars eqs = runDesugar 0 $ match vars eqs
 
 boolTy :: Type
-boolTy = TyCon $ TyConInfo "Bool" 0 KStar
+boolTy = TyCon $ TyConInfo "Bool" 0 [] KStar
 
 mkVal :: Typed Ident -> Expr
 mkVal x' = EVar $ VVal x'

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -38,7 +38,7 @@ match'
 match' vars eqs = runDesugar 0 $ match vars eqs
 
 boolTy :: Type
-boolTy = TyCon $ TyConInfo "Bool" 0 [] KStar
+boolTy = TyCon $ TyConInfo "Bool" 0 [] (TyConDefinition "Bool" 0 [] KStar)
 
 mkVal :: Typed Ident -> Expr
 mkVal x' = EVar $ VVal x'

--- a/tests/Amy/Syntax/ParserSpec.hs
+++ b/tests/Amy/Syntax/ParserSpec.hs
@@ -53,14 +53,14 @@ spec = do
         `shouldParse`
         Extern
           (Located (SourceSpan "" 1 8 1 8) "f")
-          (TyCon (TyConInfo $ Located (SourceSpan "" 1 13 1 15) "Int"))
+          (TyCon (TyConInfo "Int" [] (SourceSpan "" 1 13 1 15)))
       parse' externDecl "extern f :: Int -> Double"
         `shouldParse`
         Extern
           (Located (SourceSpan "" 1 8 1 8) "f")
-          ( TyCon (TyConInfo $ Located (SourceSpan "" 1 13 1 15) "Int")
+          ( TyCon (TyConInfo "Int" [] (SourceSpan "" 1 13 1 15))
             `TyFun`
-            TyCon (TyConInfo $ Located (SourceSpan "" 1 20 1 25) "Double")
+            TyCon (TyConInfo "Double" [] (SourceSpan "" 1 20 1 25))
           )
 
   describe "bindingType" $ do
@@ -69,15 +69,15 @@ spec = do
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
-          (Forall [] $ TyCon (TyConInfo $ Located (SourceSpan "" 1 6 1 8) "Int"))
+          (Forall [] $ TyCon (TyConInfo "Int" [] (SourceSpan "" 1 6 1 8)))
       parse' bindingType "f :: Int -> Double"
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
           ( Forall [] $
-            TyCon (TyConInfo $ Located (SourceSpan "" 1 6 1 8) "Int")
+            TyCon (TyConInfo "Int" [] (SourceSpan "" 1 6 1 8))
             `TyFun`
-            TyCon (TyConInfo $ Located (SourceSpan "" 1 13 1 18) "Double")
+            TyCon (TyConInfo "Double" [] (SourceSpan "" 1 13 1 18))
           )
 
     it "parses polymorphic types" $ do
@@ -102,50 +102,50 @@ spec = do
 
   describe "parseType" $ do
     it "handles simple types" $ do
-      parse' parseType "A" `shouldParse` TyCon (TyConInfo $ Located (SourceSpan "" 1 1 1 1) "A")
+      parse' parseType "A" `shouldParse` TyCon (TyConInfo "A" [] (SourceSpan "" 1 1 1 1))
       parse' parseType "A -> B"
         `shouldParse` (
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 1 1 1) "A")
+          TyCon (TyConInfo "A" [] (SourceSpan "" 1 1 1 1))
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 6 1 6) "B")
+          TyCon (TyConInfo "B" [] (SourceSpan "" 1 6 1 6))
         )
       parse' parseType "A -> B -> C"
         `shouldParse` (
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 1 1 1) "A")
+          TyCon (TyConInfo "A" [] (SourceSpan "" 1 1 1 1))
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 6 1 6) "B")
+          TyCon (TyConInfo "B" [] (SourceSpan "" 1 6 1 6))
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 11 1 11) "C")
+          TyCon (TyConInfo "C" [] (SourceSpan "" 1 11 1 11))
         )
 
     it "handles parens" $ do
-      parse' parseType "(A)" `shouldParse` TyCon (TyConInfo $ Located (SourceSpan "" 1 2 1 2) "A")
-      parse' parseType "((X))" `shouldParse` TyCon (TyConInfo $ Located (SourceSpan "" 1 3 1 3) "X")
+      parse' parseType "(A)" `shouldParse` TyCon (TyConInfo "A" [] (SourceSpan "" 1 2 1 2))
+      parse' parseType "((X))" `shouldParse` TyCon (TyConInfo "X" [] (SourceSpan "" 1 3 1 3))
       parse' parseType "((A)) -> ((B))"
         `shouldParse` (
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 3 1 3) "A")
+          TyCon (TyConInfo "A" [] (SourceSpan "" 1 3 1 3))
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 12 1 12) "B")
+          TyCon (TyConInfo "B" [] (SourceSpan "" 1 12 1 12))
         )
       parse' parseType "(A -> B) -> C"
         `shouldParse` (
-          ( TyCon (TyConInfo $ Located (SourceSpan "" 1 2 1 2) "A")
+          ( TyCon (TyConInfo "A" [] (SourceSpan "" 1 2 1 2))
             `TyFun`
-            TyCon (TyConInfo $ Located (SourceSpan "" 1 7 1 7) "B")
+            TyCon (TyConInfo "B" [] (SourceSpan "" 1 7 1 7))
           )
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 13 1 13) "C")
+          TyCon (TyConInfo "C" [] (SourceSpan "" 1 13 1 13))
         )
       parse' parseType "A -> (B -> C) -> D"
         `shouldParse` (
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 1 1 1) "A")
+          TyCon (TyConInfo "A" [] (SourceSpan "" 1 1 1 1))
           `TyFun`
-          ( TyCon (TyConInfo $ Located (SourceSpan "" 1 7 1 7) "B")
+          ( TyCon (TyConInfo "B" [] (SourceSpan "" 1 7 1 7))
             `TyFun`
-             TyCon (TyConInfo $ Located (SourceSpan "" 1 12 1 12) "C")
+             TyCon (TyConInfo "C" [] (SourceSpan "" 1 12 1 12))
           )
           `TyFun`
-          TyCon (TyConInfo $ Located (SourceSpan "" 1 18 1 18) "D")
+          TyCon (TyConInfo "D" [] (SourceSpan "" 1 18 1 18))
         )
 
     it "should fail gracefully without infinite loops" $ do


### PR DESCRIPTION
This PR adds polymorphic data types to Amy like `Either a b = Left a | Right b`. I still have some cleanup to do, but so far it works great :tada: 

This ended up being quite tricky because there were so many places where I used the type argument from a `TyConInfo` as the type of a term instead of the type that was actually unified for that term. This worked fine before polymorphism because if we passed the type checker those two types would match. With polymorphism though, a type variable in the original type definition could very well be specialized to a different type variable or a concrete type.

This required almost no changes to the ANF IR or code generator, which is awesome because it means some recent design decisions I made to those paid off. In particular, representing any polymorphic type as just an `OpaquePointer` worked fine, even for these polymorphic values in sum types.

I'm starting to worry about the trouble of not using symbol tables. I had a _lot_ of places where I forgot to do substitution, type instantiation, etc. Having the full `TypeDefinition` and `TyConInfo` for each node seems to be more trouble than it's worth currently.