### PR TITLE
Kind inference

### DIFF
--- a/examples/data.ll
+++ b/examples/data.ll
@@ -19,19 +19,19 @@ entry:
   %4 = alloca i8
   store i8 1, i8* %4
   %y = load i8, i8* %4
-  %z31 = alloca %Nat
-  %5 = getelementptr %Nat, %Nat* %z31, i32 0, i32 0
+  %z1 = alloca %Nat
+  %5 = getelementptr %Nat, %Nat* %z1, i32 0, i32 0
   store i1 false, i1* %5
-  %z32 = alloca %Nat
-  %6 = getelementptr %Nat, %Nat* %z32, i32 0, i32 0
+  %z2 = alloca %Nat
+  %6 = getelementptr %Nat, %Nat* %z2, i32 0, i32 0
   store i1 true, i1* %6
-  %7 = bitcast %Nat* %z31 to i64*
-  %8 = getelementptr %Nat, %Nat* %z32, i32 0, i32 1
+  %7 = bitcast %Nat* %z1 to i64*
+  %8 = getelementptr %Nat, %Nat* %z2, i32 0, i32 1
   store i64* %7, i64** %8
   %z = alloca %Nat
   %9 = getelementptr %Nat, %Nat* %z, i32 0, i32 0
   store i1 true, i1* %9
-  %10 = bitcast %Nat* %z32 to i64*
+  %10 = bitcast %Nat* %z2 to i64*
   %11 = getelementptr %Nat, %Nat* %z, i32 0, i32 1
   store i64* %10, i64** %11
   %12 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
@@ -45,7 +45,7 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u24 = load i64, i64* %15
+  %_u2 = load i64, i64* %15
   %16 = alloca i64
   store i64 0, i64* %16
   %17 = load i64, i64* %16
@@ -53,8 +53,8 @@ case.0.ret:                                       ; preds = %entry, %entry
 
 case.1.ret:                                       ; preds = %entry
   %18 = bitcast i64* %15 to double*
-  %_u25 = load double, double* %18
-  %19 = call i64 @f(double %_u25, i8 %y)
+  %_u3 = load double, double* %18
+  %19 = call i64 @f(double %_u3, i8 %y)
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
@@ -113,9 +113,9 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %_u28 = bitcast i64* %3 to %Nat*
-  %res33 = call i64 @countNat(%Nat* %_u28)
-  %6 = add i64 1, %res33
+  %_u6 = bitcast i64* %3 to %Nat*
+  %res3 = call i64 @countNat(%Nat* %_u6)
+  %6 = add i64 1, %res3
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret

--- a/examples/fib.ll
+++ b/examples/fib.ll
@@ -19,12 +19,12 @@ entry:
 case.default.ret:                                 ; preds = %entry
   %0 = alloca i64
   store i64 %x, i64* %0
-  %c15 = load i64, i64* %0
-  %res18 = sub i64 %c15, 1
-  %res19 = call i64 @fib(i64 %res18)
-  %res20 = sub i64 %c15, 2
-  %res21 = call i64 @fib(i64 %res20)
-  %1 = add i64 %res19, %res21
+  %c1 = load i64, i64* %0
+  %res1 = sub i64 %c1, 1
+  %res2 = call i64 @fib(i64 %res1)
+  %res3 = sub i64 %c1, 2
+  %res4 = call i64 @fib(i64 %res3)
+  %1 = add i64 %res2, %res4
   br label %case.end.ret
 
 case.0.ret:                                       ; preds = %entry

--- a/examples/let.ll
+++ b/examples/let.ll
@@ -13,14 +13,14 @@ entry:
   ]
 
 case.0.x:                                         ; preds = %entry, %entry
-  %x16 = call i64 @f(i64 100)
-  %0 = call i64 @abs(i64 %x16)
+  %x1 = call i64 @f(i64 100)
+  %0 = call i64 @abs(i64 %x1)
   br label %case.end.x
 
 case.1.x:                                         ; preds = %entry
-  %x17 = call i64 @threeHundred()
-  %x18 = call i64 @f(i64 %x17)
-  %1 = call i64 @abs(i64 %x18)
+  %x2 = call i64 @threeHundred()
+  %x3 = call i64 @f(i64 %x2)
+  %1 = call i64 @abs(i64 %x3)
   br label %case.end.x
 
 case.end.x:                                       ; preds = %case.1.x, %case.0.x
@@ -44,9 +44,9 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %res19 = call i64 @threeHundred()
+  %res4 = call i64 @threeHundred()
   %1 = alloca i64
-  store i64 %res19, i64* %1
+  store i64 %res4, i64* %1
   %2 = load i64, i64* %1
   br label %case.end.ret
 

--- a/examples/poly-data.ll
+++ b/examples/poly-data.ll
@@ -7,10 +7,10 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %res67 = call %Either* @f()
-  %0 = getelementptr %Either, %Either* %res67, i32 0, i32 0
+  %res1 = call %Either* @f()
+  %0 = getelementptr %Either, %Either* %res1, i32 0, i32 0
   %1 = load i1, i1* %0
-  %2 = getelementptr %Either, %Either* %res67, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res1, i32 0, i32 1
   %3 = load i64*, i64** %2
   switch i1 %1, label %case.0.ret [
     i1 false, label %case.0.ret
@@ -18,18 +18,18 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u60 = load i64, i64* %3
+  %_u7 = load i64, i64* %3
   %4 = alloca i64
-  store i64 %_u60, i64* %4
+  store i64 %_u7, i64* %4
   %5 = load i64, i64* %4
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %_u61 = load i64, i64* %3
-  %res68 = call %Either* @h()
-  %6 = getelementptr %Either, %Either* %res68, i32 0, i32 0
+  %_u8 = load i64, i64* %3
+  %res2 = call %Either* @h()
+  %6 = getelementptr %Either, %Either* %res2, i32 0, i32 0
   %7 = load i1, i1* %6
-  %8 = getelementptr %Either, %Either* %res68, i32 0, i32 1
+  %8 = getelementptr %Either, %Either* %res2, i32 0, i32 1
   %9 = load i64*, i64** %8
   switch i1 %7, label %case.0.6 [
     i1 false, label %case.0.6
@@ -37,17 +37,17 @@ case.1.ret:                                       ; preds = %entry
   ]
 
 case.0.6:                                         ; preds = %case.1.ret, %case.1.ret
-  %_u56 = load i64, i64* %9
+  %_u3 = load i64, i64* %9
   %10 = alloca i64
-  store i64 %_u56, i64* %10
+  store i64 %_u3, i64* %10
   %11 = load i64, i64* %10
   br label %case.end.6
 
 case.1.6:                                         ; preds = %case.1.ret
-  %_u57 = bitcast i64* %9 to %Either*
-  %12 = getelementptr %Either, %Either* %_u57, i32 0, i32 0
+  %_u4 = bitcast i64* %9 to %Either*
+  %12 = getelementptr %Either, %Either* %_u4, i32 0, i32 0
   %13 = load i1, i1* %12
-  %14 = getelementptr %Either, %Either* %_u57, i32 0, i32 1
+  %14 = getelementptr %Either, %Either* %_u4, i32 0, i32 1
   %15 = load i64*, i64** %14
   switch i1 %13, label %case.0.13 [
     i1 false, label %case.0.13
@@ -55,16 +55,16 @@ case.1.6:                                         ; preds = %case.1.ret
   ]
 
 case.0.13:                                        ; preds = %case.1.6, %case.1.6
-  %_u58 = load i64, i64* %15
+  %_u5 = load i64, i64* %15
   %16 = alloca i64
-  store i64 %_u58, i64* %16
+  store i64 %_u5, i64* %16
   %17 = load i64, i64* %16
   br label %case.end.13
 
 case.1.13:                                        ; preds = %case.1.6
-  %_u59 = load i64, i64* %15
+  %_u6 = load i64, i64* %15
   %18 = alloca i64
-  store i64 %_u61, i64* %18
+  store i64 %_u8, i64* %18
   %19 = load i64, i64* %18
   br label %case.end.13
 
@@ -83,16 +83,16 @@ case.end.ret:                                     ; preds = %case.end.6, %case.0
 
 define private %Either* @f() {
 entry:
-  %res69 = alloca %Either
-  %0 = getelementptr %Either, %Either* %res69, i32 0, i32 0
+  %res3 = alloca %Either
+  %0 = getelementptr %Either, %Either* %res3, i32 0, i32 0
   store i1 false, i1* %0
   %1 = alloca i64
   store i64 42, i64* %1
-  %2 = getelementptr %Either, %Either* %res69, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res3, i32 0, i32 1
   store i64* %1, i64** %2
-  %3 = getelementptr %Either, %Either* %res69, i32 0, i32 0
+  %3 = getelementptr %Either, %Either* %res3, i32 0, i32 0
   %4 = load i1, i1* %3
-  %5 = getelementptr %Either, %Either* %res69, i32 0, i32 1
+  %5 = getelementptr %Either, %Either* %res3, i32 0, i32 1
   %6 = load i64*, i64** %5
   switch i1 %4, label %case.0.ret [
     i1 false, label %case.0.ret
@@ -100,12 +100,12 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u63 = load i64, i64* %6
+  %_u10 = load i64, i64* %6
   %7 = alloca %Either
   %8 = getelementptr %Either, %Either* %7, i32 0, i32 0
   store i1 false, i1* %8
   %9 = alloca i64
-  store i64 %_u63, i64* %9
+  store i64 %_u10, i64* %9
   %10 = getelementptr %Either, %Either* %7, i32 0, i32 1
   store i64* %9, i64** %10
   br label %case.end.ret
@@ -113,12 +113,12 @@ case.0.ret:                                       ; preds = %entry, %entry
 case.1.ret:                                       ; preds = %entry
   %11 = alloca i64*
   store i64* %6, i64** %11
-  %_u64 = load i64*, i64** %11
+  %_u11 = load i64*, i64** %11
   %12 = alloca %Either
   %13 = getelementptr %Either, %Either* %12, i32 0, i32 0
   store i1 true, i1* %13
   %14 = getelementptr %Either, %Either* %12, i32 0, i32 1
-  store i64* %_u64, i64** %14
+  store i64* %_u11, i64** %14
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
@@ -128,17 +128,17 @@ case.end.ret:                                     ; preds = %case.1.ret, %case.0
 
 define private %Either* @h() {
 entry:
-  %res70 = alloca %Either
-  %0 = getelementptr %Either, %Either* %res70, i32 0, i32 0
+  %res4 = alloca %Either
+  %0 = getelementptr %Either, %Either* %res4, i32 0, i32 0
   store i1 true, i1* %0
   %1 = alloca i64
   store i64 1, i64* %1
-  %2 = getelementptr %Either, %Either* %res70, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res4, i32 0, i32 1
   store i64* %1, i64** %2
   %ret = alloca %Either
   %3 = getelementptr %Either, %Either* %ret, i32 0, i32 0
   store i1 true, i1* %3
-  %4 = bitcast %Either* %res70 to i64*
+  %4 = bitcast %Either* %res4 to i64*
   %5 = getelementptr %Either, %Either* %ret, i32 0, i32 1
   store i64* %4, i64** %5
   ret %Either* %ret

--- a/examples/poly.ll
+++ b/examples/poly.ll
@@ -10,17 +10,17 @@ entry:
   %1 = bitcast double* %0 to i64*
   %2 = call i64* @id(i64* %1)
   %3 = bitcast i64* %2 to double*
-  %res15 = load double, double* %3
+  %res1 = load double, double* %3
   %4 = alloca double
-  store double %res15, double* %4
+  store double %res1, double* %4
   %5 = bitcast double* %4 to i64*
   %6 = alloca double
   store double 5.100000e+00, double* %6
   %7 = bitcast double* %6 to i64*
   %8 = call i64* @const(i64* %5, i64* %7)
   %9 = bitcast i64* %8 to double*
-  %res16 = load double, double* %9
-  %ret = fptoui double %res16 to i64
+  %res2 = load double, double* %9
+  %ret = fptoui double %res2 to i64
   ret i64 %ret
 }
 

--- a/examples/primops.ll
+++ b/examples/primops.ll
@@ -8,17 +8,17 @@ entry:
   %0 = alloca i64
   store i64 2, i64* %0
   %x = load i64, i64* %0
-  %res18 = call i64 @f(i64 %x)
-  %ret = call i64 @f(i64 %res18)
+  %res1 = call i64 @f(i64 %x)
+  %ret = call i64 @f(i64 %res1)
   ret i64 %ret
 }
 
 define private i64 @f(i64 %x) {
 entry:
   %y = add i64 %x, -1
-  %res20 = sub i64 3, %y
-  %res21 = icmp slt i64 5, %res20
-  switch i1 %res21, label %case.0.ret [
+  %res3 = sub i64 3, %y
+  %res4 = icmp slt i64 5, %res3
+  switch i1 %res4, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]

--- a/examples/records.ll
+++ b/examples/records.ll
@@ -7,22 +7,22 @@ source_filename = "<string>"
 
 define i64 @main() {
 entry:
-  %res31 = alloca { i64, i64 }
-  %0 = getelementptr { i64, i64 }, { i64, i64 }* %res31, i32 0, i32 0
+  %res1 = alloca { i64, i64 }
+  %0 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 0
   store i64 1, i64* %0
-  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res31, i32 0, i32 1
+  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 1
   store i64 2, i64* %1
-  %ret = call i64 @addXY({ i64, i64 }* %res31)
+  %ret = call i64 @addXY({ i64, i64 }* %res1)
   ret i64 %ret
 }
 
 define private i64 @addXY({ i64, i64 }* %r) {
 entry:
   %0 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 0
-  %res32 = load i64, i64* %0
+  %res2 = load i64, i64* %0
   %1 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 1
-  %res33 = load i64, i64* %1
-  %ret = add i64 %res32, %res33
+  %res3 = load i64, i64* %1
+  %ret = add i64 %res2, %res3
   ret i64 %ret
 }
 
@@ -38,29 +38,29 @@ entry:
 
 define private %List* @h(i64* %x) {
 entry:
-  %cdr34 = alloca %List
-  %0 = getelementptr %List, %List* %cdr34, i32 0, i32 0
+  %cdr4 = alloca %List
+  %0 = getelementptr %List, %List* %cdr4, i32 0, i32 0
   store i1 false, i1* %0
-  %cdr35 = alloca { i64*, %List* }
-  %1 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr35, i32 0, i32 0
+  %cdr5 = alloca { i64*, %List* }
+  %1 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 0
   store i64* %x, i64** %1
-  %2 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr35, i32 0, i32 1
-  store %List* %cdr34, %List** %2
-  %cdr36 = alloca %List
-  %3 = getelementptr %List, %List* %cdr36, i32 0, i32 0
+  %2 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 1
+  store %List* %cdr4, %List** %2
+  %cdr6 = alloca %List
+  %3 = getelementptr %List, %List* %cdr6, i32 0, i32 0
   store i1 true, i1* %3
-  %4 = bitcast { i64*, %List* }* %cdr35 to i64*
-  %5 = getelementptr %List, %List* %cdr36, i32 0, i32 1
+  %4 = bitcast { i64*, %List* }* %cdr5 to i64*
+  %5 = getelementptr %List, %List* %cdr6, i32 0, i32 1
   store i64* %4, i64** %5
-  %res37 = alloca { i64*, %List* }
-  %6 = getelementptr { i64*, %List* }, { i64*, %List* }* %res37, i32 0, i32 0
+  %res7 = alloca { i64*, %List* }
+  %6 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 0
   store i64* %x, i64** %6
-  %7 = getelementptr { i64*, %List* }, { i64*, %List* }* %res37, i32 0, i32 1
-  store %List* %cdr36, %List** %7
+  %7 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 1
+  store %List* %cdr6, %List** %7
   %ret = alloca %List
   %8 = getelementptr %List, %List* %ret, i32 0, i32 0
   store i1 true, i1* %8
-  %9 = bitcast { i64*, %List* }* %res37 to i64*
+  %9 = bitcast { i64*, %List* }* %res7 to i64*
   %10 = getelementptr %List, %List* %ret, i32 0, i32 1
   store i64* %9, i64** %10
   ret %List* %ret

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -19,7 +19,7 @@ import Amy.Core.AST as C
 import Amy.Prim
 
 normalizeModule :: C.Module -> ANF.Module
-normalizeModule (C.Module bindings externs typeDeclarations maxId) =
+normalizeModule (C.Module bindings externs typeDeclarations) =
   let
     -- Record top-level names
     topLevelNames =
@@ -28,8 +28,7 @@ normalizeModule (C.Module bindings externs typeDeclarations maxId) =
 
     -- Actual conversion
     convertRead = anfConvertRead topLevelNames typeDeclarations
-    convertState = anfConvertState (maxId + 1)
-  in runANFConvert convertRead convertState $ do
+  in runANFConvert convertRead $ do
     typeDeclarations' <- traverse convertTypeDeclaration typeDeclarations
     externs' <- traverse convertExtern externs
     bindings' <- traverse (normalizeBinding (Just "res")) bindings

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -33,8 +33,8 @@ import Amy.Prim
 newtype ANFConvert a = ANFConvert (ReaderT ANFConvertRead (State ANFConvertState) a)
   deriving (Functor, Applicative, Monad, MonadReader ANFConvertRead, MonadState ANFConvertState)
 
-runANFConvert :: ANFConvertRead -> ANFConvertState -> ANFConvert a -> a
-runANFConvert read' state' (ANFConvert action) = evalState (runReaderT action read') state'
+runANFConvert :: ANFConvertRead -> ANFConvert a -> a
+runANFConvert read' (ANFConvert action) = evalState (runReaderT action read') (anfConvertState 0)
 
 data ANFConvertRead
   = ANFConvertRead

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -45,7 +45,6 @@ data Module
   { moduleBindings :: ![Binding]
   , moduleExterns :: ![Extern]
   , moduleTypeDeclarations :: ![TypeDeclaration]
-  , moduleMaxId :: !Int
   } deriving (Show, Eq)
 
 data Binding

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -14,13 +14,12 @@ import Amy.Prim
 import Amy.TypeCheck.AST as T
 
 desugarModule :: T.Module -> C.Module
-desugarModule (T.Module bindings externs typeDeclarations maxId) = do
+desugarModule (T.Module bindings externs typeDeclarations) = do
   let typeDeclarations' = desugarTypeDeclaration <$> typeDeclarations
-  runDesugar (maxId + 1) typeDeclarations' $ do
+  runDesugar typeDeclarations' $ do
     bindings' <- traverse desugarBinding bindings
     let externs' = desugarExtern <$> externs
-    maxId' <- freshId
-    pure $ C.Module bindings' externs' typeDeclarations' maxId'
+    pure $ C.Module bindings' externs' typeDeclarations'
 
 desugarExtern :: T.Extern -> C.Extern
 desugarExtern (T.Extern ident ty) = C.Extern ident (desugarType ty)

--- a/library/Amy/Core/Monad.hs
+++ b/library/Amy/Core/Monad.hs
@@ -20,8 +20,8 @@ import Amy.Core.AST as C
 newtype Desugar a = Desugar (ReaderT (Map DataConName (TypeDeclaration, DataConDefinition)) (State Int) a)
   deriving (Functor, Applicative, Monad, MonadReader (Map DataConName (TypeDeclaration, DataConDefinition)), MonadState Int)
 
-runDesugar :: Int -> [TypeDeclaration] -> Desugar a -> a
-runDesugar maxId decls (Desugar action) = evalState (runReaderT action dataConMap) maxId
+runDesugar :: [TypeDeclaration] -> Desugar a -> a
+runDesugar decls (Desugar action) = evalState (runReaderT action dataConMap) 0
  where
   dataConMap = Map.fromList $ concatMap mkDataConTypes decls
 

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -35,7 +35,7 @@ prettyScheme' :: Scheme -> Doc ann
 prettyScheme' (Forall vars ty) = prettyScheme (prettyTyVarName <$> vars) (prettyType ty)
 
 prettyModule :: Module -> Doc ann
-prettyModule (Module bindings externs typeDeclarations _) =
+prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines
   $ (prettyExtern' <$> externs)
   ++ (prettyTypeDeclaration' <$> typeDeclarations)

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -32,6 +32,7 @@ data Error
   -- Type checker
   -- TODO: Add source spans here
   | UnificationFail !T.Type !T.Type
+  | KindUnificationFail !Kind ! Kind
   | KindMismatch !T.TyConName !Kind !T.TyConDefinition !Kind
   | InfiniteType !T.TyVarInfo !T.Type
   | UnboundVariable !IdentName
@@ -58,6 +59,7 @@ errorLocation e =
     UnknownTypeVariable (Located s _) -> Just s
 
     UnificationFail{} -> Nothing
+    KindUnificationFail{} -> Nothing
     KindMismatch{} -> Nothing
     InfiniteType{} -> Nothing
     UnboundVariable{} -> Nothing

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -35,6 +35,7 @@ data Error
   | KindUnificationFail !Kind ! Kind
   | KindMismatch !T.TyConName !Kind !T.TyConDefinition !Kind
   | InfiniteType !T.TyVarInfo !T.Type
+  | InfiniteKind !Int !Kind
   | UnboundVariable !IdentName
 
   -- | BindingLacksTypeSignature !RBinding
@@ -62,6 +63,7 @@ errorLocation e =
     KindUnificationFail{} -> Nothing
     KindMismatch{} -> Nothing
     InfiniteType{} -> Nothing
+    InfiniteKind{} -> Nothing
     UnboundVariable{} -> Nothing
 
     -- BindingLacksTypeSignature bind -> Just $ locatedSpan $ rBindingName bind

--- a/library/Amy/Kind.hs
+++ b/library/Amy/Kind.hs
@@ -4,6 +4,8 @@ module Amy.Kind
 
 data Kind
   = KStar
+  | KUnknown !Int
+  | KRow
   | KFun !Kind !Kind
   deriving (Show, Eq, Ord)
 

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -49,10 +49,6 @@ data Module
   { moduleBindings :: ![Binding]
   , moduleExterns :: ![Extern]
   , moduleTypeDeclarations :: ![TypeDeclaration]
-    -- TODO: Instead of threading an Int through every AST Module, consider
-    -- running the whole compiler in some monad that admits a fresh name
-    -- supply. I'm not sure if that would make things easier at the expense of
-  , moduleMaxId :: !Int
   } deriving (Show, Eq)
 
 -- | A binding after renaming. This is a combo of a 'Binding' and a

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -47,6 +47,8 @@ inferModule (R.Module bindings externs typeDeclarations) = do
       { identTypes = Map.fromList $ externSchemes ++ primFuncSchemes
       , typeDefinitions = Map.fromList tyDefs
       , dataConstructorTypes = Map.fromList $ concatMap mkDataConTypes typeDeclarations'
+      , tyVarKinds = Map.empty
+      , tyConKinds = Map.empty
       , maxId = 0
       }
   bindings' <- inferTopLevel env bindings

--- a/library/Amy/TypeCheck/Inference.hs
+++ b/library/Amy/TypeCheck/Inference.hs
@@ -78,8 +78,8 @@ inferModule (R.Module bindings externs typeDeclarations) = do
       , typeDefinitions = Map.fromList tyDefs
       , dataConstructorTypes = Map.fromList $ concatMap mkDataConTypes typeDeclarations'
       }
-  (bindings', maxId') <- inferTopLevel 0 env bindings
-  pure (T.Module bindings' externs' typeDeclarations' maxId')
+  bindings' <- inferTopLevel env bindings
+  pure (T.Module bindings' externs' typeDeclarations')
 
 convertExtern :: R.Extern -> T.Extern
 convertExtern (R.Extern (Located _ name) ty) = T.Extern name (convertType ty)
@@ -124,8 +124,8 @@ primitiveFunctionScheme (PrimitiveFunction _ name ty) =
   , T.Forall [] $ foldr1 T.TyFun $ T.TyCon <$> ty
   )
 
-inferTopLevel :: Int -> TyEnv -> [R.Binding] -> Either Error ([T.Binding], Int)
-inferTopLevel maxId env bindings = runInference maxId env $ do
+inferTopLevel :: TyEnv -> [R.Binding] -> Either Error [T.Binding]
+inferTopLevel env bindings = runInference env $ do
   bindingsAndConstraints <- inferBindings bindings
   let (bindings', constraints) = unzip bindingsAndConstraints
   subst <- runSolve (concat constraints)

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -142,18 +142,18 @@ solver (su, cs) =
   case cs of
     [] -> return su
     (Constraint (t1, t2): cs0) -> do
-      su1 <- unify t1 t2
+      su1 <- unifyKinds t1 t2
       solver (su1 `composeSubst` su, substituteConstraint su1 <$> cs0)
 
-unify :: Kind -> Kind -> KindInference Subst
-unify k1 k2 | k1 == k2 = pure emptySubst
-unify (KUnknown i) k = i `bind` k
-unify k (KUnknown i) = i `bind` k
-unify (KFun k1 k2) (KFun k3 k4) = do
-  su1 <- unify k1 k3
-  su2 <- unify (substituteKind su1 k2) (substituteKind su1 k4)
+unifyKinds :: Kind -> Kind -> KindInference Subst
+unifyKinds k1 k2 | k1 == k2 = pure emptySubst
+unifyKinds (KUnknown i) k = i `bind` k
+unifyKinds k (KUnknown i) = i `bind` k
+unifyKinds (KFun k1 k2) (KFun k3 k4) = do
+  su1 <- unifyKinds k1 k3
+  su2 <- unifyKinds (substituteKind su1 k2) (substituteKind su1 k4)
   pure (su2 `composeSubst` su1)
-unify k1 k2 = throwError $ KindUnificationFail k1 k2
+unifyKinds k1 k2 = throwError $ KindUnificationFail k1 k2
 
 bind :: Int -> Kind -> KindInference Subst
 bind i k

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -5,7 +5,6 @@ module Amy.TypeCheck.KindInference
   ) where
 
 import Control.Monad.Except
-import Control.Monad.State.Strict
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
@@ -16,52 +15,7 @@ import Data.Traversable (for)
 import Amy.Errors
 import Amy.Kind
 import Amy.TypeCheck.AST
-
---
--- Inference Monad
---
-
-newtype KindInference a = KindInference (StateT KindInferenceState (Except Error) a)
-  deriving (Functor, Applicative, Monad, MonadState KindInferenceState, MonadError Error)
-
-data KindInferenceState
-  = KindInferenceState
-  { maxId :: !Int
-  , tyVarKinds :: !(Map TyVarName Kind)
-  , tyConKinds :: !(Map TyConName Kind)
-  } deriving (Show, Eq)
-
-runKindInference :: KindInference a -> Either Error a
-runKindInference (KindInference action) = runExcept $ evalStateT action (KindInferenceState 0 Map.empty Map.empty)
-
-freshKindVariable :: KindInference Int
-freshKindVariable = do
-  modify' (\s -> s { maxId = maxId s + 1 })
-  gets maxId
-
-addUnknownTyVarKind :: TyVarName -> KindInference Int
-addUnknownTyVarKind name = do
-  i <- freshKindVariable
-  modify' (\s -> s { tyVarKinds = Map.insert name (KUnknown i) (tyVarKinds s) })
-  pure i
-
-addUnknownTyConKind :: TyConName -> KindInference Int
-addUnknownTyConKind name = do
-  i <- freshKindVariable
-  modify' (\s -> s { tyConKinds = Map.insert name (KUnknown i) (tyConKinds s) })
-  pure i
-
-lookupTyVarKind :: TyVarName -> KindInference Kind
-lookupTyVarKind name =
-  fromMaybe (error $ "Can't find kind for name, Renamer must have messed up " ++ show name)
-  . Map.lookup name
-  <$> gets tyVarKinds
-
-lookupTyConKind :: TyConName -> KindInference Kind
-lookupTyConKind name =
-  fromMaybe (error $ "Can't find kind for name, Renamer must have messed up " ++ show name)
-  . Map.lookup name
-  <$> gets tyConKinds
+import Amy.TypeCheck.Monad
 
 --
 -- Kind Inference
@@ -70,29 +24,27 @@ lookupTyConKind name =
 -- TODO: Infer the kinds of mutually recursive type declaration groups at the
 -- same time instead of one by one.
 
-inferTypeDeclarationKind :: TypeDeclaration -> Either Error Kind
-inferTypeDeclarationKind = runKindInference . inferTypeDeclarationKind'
+inferTypeDeclarationKind :: TypeDeclaration -> Inference Kind
+inferTypeDeclarationKind (TypeDeclaration (TyConDefinition tyCon tyArgs) constructors) =
+  withNewLexicalScope $ do
+    -- Generate unknown kind variables for the type constructor and all type
+    -- variables.
+    tyConKindVar <- addUnknownTyConKindToScope tyCon
+    tyVarKindVars <- traverse addUnknownTyVarKindToScope tyArgs
+    let
+      tyConConstraint = Constraint (KUnknown tyConKindVar, foldr1 KFun $ (KUnknown <$> tyVarKindVars) ++ [KStar])
 
-inferTypeDeclarationKind' :: TypeDeclaration -> KindInference Kind
-inferTypeDeclarationKind' (TypeDeclaration (TyConDefinition tyCon tyArgs) constructors) = do
-  -- Generate unknown kind variables for the type constructor and all type
-  -- variables.
-  tyConKindVar <- addUnknownTyConKind tyCon
-  tyVarKindVars <- traverse addUnknownTyVarKind tyArgs
-  let
-    tyConConstraint = Constraint (KUnknown tyConKindVar, foldr1 KFun $ (KUnknown <$> tyVarKindVars) ++ [KStar])
+    -- Traverse constructors to collect constraints.
+    (_, constructorCons) <- unzip <$> traverse inferTypeKind (mapMaybe dataConDefinitionArgument constructors)
 
-  -- Traverse constructors to collect constraints.
-  (_, constructorCons) <- unzip <$> traverse inferTypeKind (mapMaybe dataConDefinitionArgument constructors)
+    -- Solve constraints
+    (Subst subst) <- solver (emptySubst, tyConConstraint : concat constructorCons)
 
-  -- Solve constraints
-  (Subst subst) <- solver (emptySubst, tyConConstraint : concat constructorCons)
+    -- Substitute into tyConKindVar and return
+    let kind = fromMaybe (error "Lost the input kind") $ Map.lookup tyConKindVar subst
+    pure $ starIfUnknown kind
 
-  -- Substitute into tyConKindVar and return
-  let kind = fromMaybe (error "Lost the input kind") $ Map.lookup tyConKindVar subst
-  pure $ starIfUnknown kind
-
-inferTypeKind :: Type -> KindInference (Kind, [Constraint])
+inferTypeKind :: Type -> Inference (Kind, [Constraint])
 inferTypeKind (TyCon name) = do
   kind <- lookupTyConKind name
   pure (kind, [])
@@ -102,7 +54,7 @@ inferTypeKind (TyVar (TyVarInfo name _)) = do
 inferTypeKind (TyApp t1 t2) = do
   (k1, cons1) <- inferTypeKind t1
   (k2, cons2) <- inferTypeKind t2
-  retKind <- KUnknown <$> freshKindVariable
+  retKind <- KUnknown <$> freshId
   let constraint = Constraint (k1, k2 `KFun` retKind)
   pure (KFun k1 k2, cons1 ++ cons2 ++ [constraint])
 inferTypeKind (TyFun t1 t2) = do
@@ -137,7 +89,7 @@ starIfUnknown (KFun k1 k2) = KFun (starIfUnknown k1) (starIfUnknown k2)
 newtype Constraint = Constraint (Kind, Kind)
   deriving (Show, Eq)
 
-solver :: (Subst, [Constraint]) -> KindInference Subst
+solver :: (Subst, [Constraint]) -> Inference Subst
 solver (su, cs) =
   case cs of
     [] -> return su
@@ -145,7 +97,7 @@ solver (su, cs) =
       su1 <- unifyKinds t1 t2
       solver (su1 `composeSubst` su, substituteConstraint su1 <$> cs0)
 
-unifyKinds :: Kind -> Kind -> KindInference Subst
+unifyKinds :: Kind -> Kind -> Inference Subst
 unifyKinds k1 k2 | k1 == k2 = pure emptySubst
 unifyKinds (KUnknown i) k = i `bind` k
 unifyKinds k (KUnknown i) = i `bind` k
@@ -155,7 +107,7 @@ unifyKinds (KFun k1 k2) (KFun k3 k4) = do
   pure (su2 `composeSubst` su1)
 unifyKinds k1 k2 = throwError $ KindUnificationFail k1 k2
 
-bind :: Int -> Kind -> KindInference Subst
+bind :: Int -> Kind -> Inference Subst
 bind i k
   | k == KUnknown i = pure emptySubst
   | occursCheck i k = throwError $ InfiniteKind i k

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Amy.TypeCheck.KindInference
+  ( inferTypeDeclarationKind
+  ) where
+
+import Control.Monad.Except
+import Control.Monad.State.Strict
+import Data.Foldable (traverse_)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Traversable (for)
+
+import Amy.Errors
+import Amy.Kind
+import Amy.TypeCheck.AST
+
+--
+-- Inference Monad
+--
+
+newtype KindInference a = KindInference (StateT KindInferenceState (Except Error) a)
+  deriving (Functor, Applicative, Monad, MonadState KindInferenceState, MonadError Error)
+
+data KindInferenceState
+  = KindInferenceState
+  { maxId :: !Int
+  , tyVarKinds :: !(Map TyVarName Kind)
+  , tyConKinds :: !(Map TyConName Kind)
+  } deriving (Show, Eq)
+
+runKindInference :: KindInference a -> Either Error a
+runKindInference (KindInference action) = runExcept $ evalStateT action (KindInferenceState 0 Map.empty Map.empty)
+
+freshKindVariable :: KindInference Kind
+freshKindVariable = do
+  modify' (\s -> s { maxId = maxId s + 1 })
+  KUnknown <$> gets maxId
+
+addUnknownTyVarKind :: TyVarName -> KindInference Kind
+addUnknownTyVarKind name = do
+  kind <- freshKindVariable
+  modify' (\s -> s { tyVarKinds = Map.insert name kind (tyVarKinds s) })
+  pure kind
+
+addUnknownTyConKind :: TyConName -> KindInference Kind
+addUnknownTyConKind name = do
+  kind <- freshKindVariable
+  modify' (\s -> s { tyConKinds = Map.insert name kind (tyConKinds s) })
+  pure kind
+
+lookupTyVarKind :: TyVarName -> KindInference Kind
+lookupTyVarKind name =
+  fromMaybe (error $ "Can't find kind for name, Renamer must have messed up " ++ show name)
+  . Map.lookup name
+  <$> gets tyVarKinds
+
+lookupTyConKind :: TyConName -> KindInference Kind
+lookupTyConKind name =
+  fromMaybe (error $ "Can't find kind for name, Renamer must have messed up " ++ show name)
+  . Map.lookup name
+  <$> gets tyConKinds
+
+--
+-- Kind Inference
+--
+
+-- TODO: Infer the kinds of mutually recursive type declaration groups at the
+-- same time instead of one by one.
+
+inferTypeDeclarationKind :: TypeDeclaration -> Either Error Kind
+inferTypeDeclarationKind = runKindInference . inferTypeDeclarationKind'
+
+inferTypeDeclarationKind' :: TypeDeclaration -> KindInference Kind
+inferTypeDeclarationKind' (TypeDeclaration (TyConDefinition tyCon tyArgs) constructors) = do
+  -- Generate unknown kind variables for the type constructor and all type
+  -- variables.
+  tyConKindVar <- addUnknownTyConKind tyCon
+  tyVarKindVars <- traverse addUnknownTyVarKind tyArgs
+  let
+    tyConConstraint = Constraint (tyConKindVar, foldr1 KFun $ tyVarKindVars ++ [KStar])
+
+  -- Traverse constructors to collect constraints.
+  (consKinds, consCons) <- unzip <$> traverse inferTypeKind (mapMaybe dataConDefinitionArgument constructors)
+
+  -- Solve constraints
+  subst <- undefined
+
+  -- Substitute into tyConKindVar and return
+
+  undefined
+
+inferTypeKind :: Type -> KindInference (Kind, [Constraint])
+inferTypeKind (TyCon name) = do
+  kind <- lookupTyConKind name
+  pure (kind, [])
+inferTypeKind (TyVar (TyVarInfo name _)) = do
+  kind <- lookupTyVarKind name
+  pure (kind, [])
+inferTypeKind (TyApp t1 t2) = do
+  (k1, cons1) <- inferTypeKind t1
+  (k2, cons2) <- inferTypeKind t2
+  retKind <- freshKindVariable
+  let constraint = Constraint (k1, k2 `KFun` retKind)
+  pure (KFun k1 k2, cons1 ++ cons2 ++ [constraint])
+inferTypeKind (TyFun t1 t2) = do
+  (k1, cons1) <- inferTypeKind t1
+  (k2, cons2) <- inferTypeKind t2
+  let constraint = Constraint (k1, k2 `KFun` KStar)
+  pure (KFun k1 k2, cons1 ++ cons2 ++ [constraint])
+inferTypeKind (TyRecord fields mVar) = do
+  fieldCons <- for (Map.elems fields) $ \ty -> do
+    (fieldKind, fieldCons) <- inferTypeKind ty
+    pure $ fieldCons ++ [Constraint (fieldKind, KStar)]
+  varCons <- for (maybeToList mVar) $ \(TyVarInfo var _) -> do
+    varKind <- lookupTyVarKind var
+    pure $ Constraint (varKind, KRow)
+  pure (KStar, concat fieldCons ++ varCons)
+
+-- | If we have any unknown kinds left, just call them KStar.
+starIfUnknown :: Kind -> Kind
+starIfUnknown KStar = KStar
+starIfUnknown (KUnknown _) = KStar
+starIfUnknown KRow = KRow
+starIfUnknown (KFun k1 k2) = KFun (starIfUnknown k1) (starIfUnknown k2)
+
+--
+-- Unification
+--
+
+newtype Constraint = Constraint (Kind, Kind)
+  deriving (Show, Eq)

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -74,8 +74,8 @@ newtype Inference a = Inference (ReaderT TyEnv (StateT Int (Except Error)) a)
 
 -- TODO: Don't use Except, use Validation
 
-runInference :: Int -> TyEnv -> Inference a -> Either Error (a, Int)
-runInference maxId env (Inference action) = runExcept $ runStateT (runReaderT action env) (maxId + 1)
+runInference :: TyEnv -> Inference a -> Either Error a
+runInference env (Inference action) = runExcept $ evalStateT (runReaderT action env) 0
 
 freshTypeVariable :: Inference T.TyVarInfo
 freshTypeVariable = do

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -41,7 +41,7 @@ prettyScheme' :: Scheme -> Doc ann
 prettyScheme' (Forall vars ty) = prettyScheme (prettyTyVarInfo <$> vars) (prettyType ty)
 
 prettyModule :: Module -> Doc ann
-prettyModule (Module bindings externs typeDeclarations _) =
+prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines
   $ (prettyExtern' <$> externs)
   ++ (prettyTypeDeclaration' <$> typeDeclarations)

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -34,7 +34,7 @@ match'
   :: [Typed IdentName]
   -> [Equation]
   -> CaseExpr
-match' vars eqs = runDesugar 0 [] $ match vars eqs
+match' vars eqs = runDesugar [] $ match vars eqs
 
 boolTy :: Type
 boolTy = TyCon "Bool"


### PR DESCRIPTION
This PR adds real kind inference instead of our simple arity checking of constructors. This is necessary because now we have row kinds. I've also refactored type inference quite a bit to support using a single `Inference` monad for kind inference and type inference.