### PR TITLE
Print much nicer errors

### DIFF
--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -47,7 +47,7 @@ process filePath DumpFlags{..} input = do
       lift $ putStrLn "\nParsed:" >> print (S.prettyModule parsed)
 
     -- Type checking
-    typeChecked <- liftEither $ first ((:[]) . showErrorMessage) $ T.inferModule parsed
+    typeChecked <- liftEither $ first ((:[]) . showError) $ T.inferModule parsed
     when dfDumpTypeChecked $
       lift $ putStrLn "\nType Checked:" >> print (T.prettyModule typeChecked)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -42,12 +42,12 @@ process :: FilePath -> DumpFlags -> Text -> IO ()
 process filePath DumpFlags{..} input = do
   eCodegenString <- runExceptT $ do
     -- Parse
-    parsed <- liftEither $ first ((:[]) . ParserError) $ parse (runAmyParser parseModule) filePath input
+    parsed <- liftEither $ first ((:[]) . parseErrorPretty) $ parse (runAmyParser parseModule) filePath input
     when dfDumpParsed $
       lift $ putStrLn "\nParsed:" >> print (S.prettyModule parsed)
 
     -- Type checking
-    typeChecked <- liftEither $ first (:[]) $ T.inferModule parsed
+    typeChecked <- liftEither $ first ((:[]) . showErrorMessage) $ T.inferModule parsed
     when dfDumpTypeChecked $
       lift $ putStrLn "\nType Checked:" >> print (T.prettyModule typeChecked)
 
@@ -75,8 +75,8 @@ process filePath DumpFlags{..} input = do
 
   either showErrors BS8.putStrLn eCodegenString
 
-showErrors :: [ErrorMessage] -> IO ()
-showErrors = hPutStrLn stderr . intercalate "\n" . fmap showErrorMessage
+showErrors :: [String] -> IO ()
+showErrors = hPutStrLn stderr . intercalate "\n"
 
 runRepl :: IO ()
 runRepl = runInputT defaultSettings loop

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -75,8 +75,8 @@ process filePath DumpFlags{..} input = do
 
   either showErrors BS8.putStrLn eCodegenString
 
-showErrors :: [Error] -> IO ()
-showErrors = hPutStrLn stderr . intercalate "\n" . fmap showError
+showErrors :: [ErrorMessage] -> IO ()
+showErrors = hPutStrLn stderr . intercalate "\n" . fmap showErrorMessage
 
 runRepl :: IO ()
 runRepl = runInputT defaultSettings loop

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -38,6 +38,8 @@ import Amy.ASTCommon
 import Amy.Literal
 import Amy.Names
 import Amy.Prim
+import qualified Amy.Syntax.AST as S
+import Amy.Syntax.Located
 
 data Module
   = Module
@@ -76,12 +78,12 @@ data TyConDefinition
   , tyConDefinitionArgs :: ![TyVarName]
   } deriving (Show, Eq, Ord)
 
-fromPrimTyDef :: TyConName -> TyConDefinition
-fromPrimTyDef name = TyConDefinition name []
+fromPrimTyDef :: S.TyConDefinition -> TyConDefinition
+fromPrimTyDef (S.TyConDefinition name args _) = TyConDefinition name (locatedValue <$> args)
 
-fromPrimTypeDefinition :: PrimTypeDefinition -> TypeDeclaration
-fromPrimTypeDefinition (PrimTypeDefinition tyName cons) =
-  TypeDeclaration (fromPrimTyDef tyName) (fromPrimDataCon <$> cons)
+fromPrimTypeDefinition :: S.TypeDeclaration -> TypeDeclaration
+fromPrimTypeDefinition (S.TypeDeclaration tyConDef dataCons) =
+  TypeDeclaration (fromPrimTyDef tyConDef) (fromPrimDataCon <$> dataCons)
 
 data DataConDefinition
   = DataConDefinition
@@ -89,8 +91,9 @@ data DataConDefinition
   , dataConDefinitionArgument :: !(Maybe Type)
   } deriving (Show, Eq, Ord)
 
-fromPrimDataCon :: DataConName -> DataConDefinition
-fromPrimDataCon name = DataConDefinition name Nothing
+fromPrimDataCon :: S.DataConDefinition -> DataConDefinition
+fromPrimDataCon (S.DataConDefinition (Located _ name) Nothing) = DataConDefinition name Nothing
+fromPrimDataCon (S.DataConDefinition _ (Just _)) = error "Couldn't convert data con definiton type."
 
 data Expr
   = ELit !Literal

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -79,7 +79,7 @@ data TyConDefinition
   } deriving (Show, Eq, Ord)
 
 fromPrimTyDef :: S.TyConDefinition -> TyConDefinition
-fromPrimTyDef (S.TyConDefinition name args _) = TyConDefinition name (locatedValue <$> args)
+fromPrimTyDef (S.TyConDefinition (Located _ name) args) = TyConDefinition name (locatedValue <$> args)
 
 fromPrimTypeDefinition :: S.TypeDeclaration -> TypeDeclaration
 fromPrimTypeDefinition (S.TypeDeclaration tyConDef dataCons) =

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -82,8 +82,7 @@ desugarExpr (T.ECase (T.Case scrutinee matches)) = do
 desugarExpr (T.EIf (T.If pred' then' else')) =
   let
     boolTyCon' = T.TyCon boolTyCon
-    mkBoolPatCons cons =
-      T.PatCons (T.dataConDefinitionName $ T.fromPrimDataCon cons) Nothing boolTyCon'
+    mkBoolPatCons cons = T.PatCons cons Nothing boolTyCon'
     matches =
       NE.fromList
       [ T.Match (T.PCons $ mkBoolPatCons trueDataCon) then'

--- a/library/Amy/Core/Monad.hs
+++ b/library/Amy/Core/Monad.hs
@@ -16,6 +16,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
 
 import Amy.Core.AST as C
+import Amy.Prim
 
 newtype Desugar a = Desugar (ReaderT (Map DataConName (TypeDeclaration, DataConDefinition)) (State Int) a)
   deriving (Functor, Applicative, Monad, MonadReader (Map DataConName (TypeDeclaration, DataConDefinition)), MonadState Int)
@@ -23,7 +24,8 @@ newtype Desugar a = Desugar (ReaderT (Map DataConName (TypeDeclaration, DataConD
 runDesugar :: [TypeDeclaration] -> Desugar a -> a
 runDesugar decls (Desugar action) = evalState (runReaderT action dataConMap) 0
  where
-  dataConMap = Map.fromList $ concatMap mkDataConTypes decls
+  allTypeDecls = decls ++ (fromPrimTypeDefinition <$> allPrimTypeDefinitions)
+  dataConMap = Map.fromList $ concatMap mkDataConTypes allTypeDecls
 
 freshId :: Desugar Int
 freshId = do

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -5,20 +5,14 @@ module Amy.Errors
   , showErrorMessage
   ) where
 
-import Data.Void (Void)
 import Text.Groom
-import Text.Megaparsec
 
 import Amy.Kind
 import Amy.Syntax.AST as S
 import Amy.TypeCheck.AST as T
 
 data ErrorMessage
-  -- Parser
-  = ParserError !(ParseError Char Void)
-
-  -- Type checker
-  | UnknownVariable !IdentName
+  = UnknownVariable !IdentName
   | UnknownDataCon !DataConName
   | UnknownTypeVariable !TyVarName
   | UnknownTypeConstructor !TyConName
@@ -33,5 +27,4 @@ data ErrorMessage
   deriving (Show, Eq)
 
 showErrorMessage :: ErrorMessage -> String
-showErrorMessage (ParserError err) = parseErrorPretty err
-showErrorMessage err = groom err
+showErrorMessage = groom

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -1,9 +1,8 @@
 -- | User facing errors.
 
 module Amy.Errors
-  ( Error(..)
-  , showError
-  , errorLocation
+  ( ErrorMessage(..)
+  , showErrorMessage
   ) where
 
 import Data.Void (Void)
@@ -14,12 +13,11 @@ import Amy.Kind
 import Amy.Syntax.AST as S
 import Amy.TypeCheck.AST as T
 
-data Error
+data ErrorMessage
   -- Parser
   = ParserError !(ParseError Char Void)
 
   -- Type checker
-  -- TODO: Add source spans here
   | UnknownVariable !IdentName
   | UnknownDataCon !DataConName
   | UnknownTypeVariable !TyVarName
@@ -34,24 +32,6 @@ data Error
   | TooManyBindingArguments !S.Binding
   deriving (Show, Eq)
 
-errorLocation :: Error -> Maybe SourceSpan
-errorLocation e =
-  case e of
-    ParserError{} -> Nothing
-
-    UnknownVariable{} -> Nothing
-    UnknownDataCon{} -> Nothing
-    UnknownTypeVariable{} -> Nothing
-    UnknownTypeConstructor{} -> Nothing
-    VariableShadowed{} -> Nothing
-    DuplicateDataConstructor{} -> Nothing
-    DuplicateTypeConstructor{} -> Nothing
-    UnificationFail{} -> Nothing
-    KindUnificationFail{} -> Nothing
-    InfiniteType{} -> Nothing
-    InfiniteKind{} -> Nothing
-    TooManyBindingArguments{} -> Nothing
-
-showError :: Error -> String
-showError (ParserError err) = parseErrorPretty err
-showError err = groom err
+showErrorMessage :: ErrorMessage -> String
+showErrorMessage (ParserError err) = parseErrorPretty err
+showErrorMessage err = groom err

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -1,17 +1,21 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | User facing errors.
 
 module Amy.Errors
   ( Error(..)
   , showError
   , ErrorMessage(..)
-  , showErrorMessage
   ) where
 
-import Text.Groom
+import Data.Text.Prettyprint.Doc.Render.String (renderString)
 
 import Amy.Kind
+import Amy.Pretty
 import Amy.Syntax.AST as S
 import Amy.TypeCheck.AST as T
+import Amy.TypeCheck.Pretty as T
 
 data Error
   = Error
@@ -20,8 +24,9 @@ data Error
   } deriving (Show, Eq)
 
 showError :: Error -> String
-showError (Error message (SourceSpan fileName line col _ _)) =
-  fileName ++ ":" ++ show line ++ ":" ++ show col ++ ":\n" ++ showErrorMessage message
+showError (Error message (SourceSpan fileName lineNo col _ _)) =
+  renderString . layoutPretty defaultLayoutOptions $
+    pretty fileName <> ":" <> pretty lineNo <> ":" <> pretty col <> ":" <> groupOrHang (prettyErrorMessage message)
 
 data ErrorMessage
   = UnknownVariable !IdentName
@@ -35,8 +40,24 @@ data ErrorMessage
   | KindUnificationFail !Kind ! Kind
   | InfiniteType !TyExistVarName !T.Type
   | InfiniteKind !Int !Kind
-  | TooManyBindingArguments !S.Binding
+  | TooManyBindingArguments !Int !Int
   deriving (Show, Eq)
 
-showErrorMessage :: ErrorMessage -> String
-showErrorMessage = groom
+prettyErrorMessage :: ErrorMessage -> Doc ann
+prettyErrorMessage = \case
+  UnknownVariable ident -> "Unknown variable:" <+> prettyIdent ident
+  UnknownDataCon con -> "Unknown data constructor:" <+> prettyDataConName con
+  UnknownTypeVariable tyvar -> "Unknown type variable:" <+> prettyTyVarName tyvar
+  UnknownTypeConstructor tycon -> "Unknown type constructor:" <+> prettyTyConName tycon
+  VariableShadowed x -> "Variable shadowed:" <+> prettyIdent x
+  DuplicateDataConstructor con -> "Data constructor already exists:" <+> prettyDataConName con
+  DuplicateTypeConstructor con -> "Type constructor already exists:" <+> prettyTyConName con
+  UnificationFail t1 t2 ->
+    "Could not match type" <> hardline <> indent 2 (T.prettyType t1) <> hardline <> "with type" <> hardline <> indent 2 (T.prettyType t2)
+  KindUnificationFail k1 k2 ->
+    "Could not match kind" <> hardline <> indent 2 (prettyKind k1) <> hardline <> "with kind" <> hardline <> indent 2 (prettyKind k2)
+  InfiniteType _ t -> "Cannot infer infinite type:" <> T.prettyType t
+  InfiniteKind _ k -> "Cannot infer infinite kind:" <> prettyKind k
+  TooManyBindingArguments expected actual ->
+    "Too many arguments to binding. Declared type implies a maximum of" <+> pretty expected <+>
+    "arguments, but found" <+> pretty actual <+> "arguments."

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -1,7 +1,9 @@
 -- | User facing errors.
 
 module Amy.Errors
-  ( ErrorMessage(..)
+  ( Error(..)
+  , showError
+  , ErrorMessage(..)
   , showErrorMessage
   ) where
 
@@ -10,6 +12,16 @@ import Text.Groom
 import Amy.Kind
 import Amy.Syntax.AST as S
 import Amy.TypeCheck.AST as T
+
+data Error
+  = Error
+  { errorMessage :: !ErrorMessage
+  , errorLocation :: !SourceSpan
+  } deriving (Show, Eq)
+
+showError :: Error -> String
+showError (Error message (SourceSpan fileName line col _ _)) =
+  fileName ++ ":" ++ show line ++ ":" ++ show col ++ ":\n" ++ showErrorMessage message
 
 data ErrorMessage
   = UnknownVariable !IdentName

--- a/library/Amy/Literal.hs
+++ b/library/Amy/Literal.hs
@@ -3,11 +3,7 @@
 module Amy.Literal
   ( Literal(..)
   , showLiteral
-  , literalType
   ) where
-
-import Amy.Names
-import Amy.Prim
 
 -- | A 'Literal' is any literal from the source code. This type is used in many
 -- ASTs since there is no need for renaming or annotating types to a literal.
@@ -19,7 +15,3 @@ data Literal
 showLiteral :: Literal -> String
 showLiteral (LiteralInt x) = show x
 showLiteral (LiteralDouble x) = show x
-
-literalType :: Literal -> TyConName
-literalType (LiteralInt _) = intTyCon
-literalType (LiteralDouble _) = doubleTyCon

--- a/library/Amy/Prim.hs
+++ b/library/Amy/Prim.hs
@@ -46,7 +46,7 @@ mkPrimTypeDef :: TyConName -> [DataConName] -> TypeDeclaration
 mkPrimTypeDef tyConName dataConNames =
   let
     span' = SourceSpan "<prim>" 1 1 1 1
-    tyConDef = TyConDefinition tyConName [] span'
+    tyConDef = TyConDefinition (Located span' tyConName) []
     mkDataConDef con = DataConDefinition (Located span' con) Nothing
     dataCons = mkDataConDef <$> dataConNames
   in TypeDeclaration tyConDef dataCons

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -44,8 +44,11 @@ import Amy.Names
 import Amy.Syntax.Located
 
 -- | A 'Module' is simply a list of 'Declaration' values.
-newtype Module = Module { unModule :: [Declaration] }
-  deriving (Show, Eq)
+data Module
+  = Module
+  { moduleFile :: !FilePath
+  , moduleDeclarations :: [Declaration]
+  } deriving (Show, Eq)
 
 data Declaration
   = DeclBinding !Binding

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -23,6 +23,7 @@ module Amy.Syntax.AST
   , Let(..)
   , letBinding
   , letBindingType
+  , expressionSpan
   , LetBinding(..)
   , Type(..)
 
@@ -133,12 +134,14 @@ data If
   { ifPredicate :: !Expr
   , ifThen :: !Expr
   , ifElse :: !Expr
+  , ifSpan :: !SourceSpan
   } deriving (Show, Eq)
 
 data Case
   = Case
   { caseScrutinee :: !Expr
   , caseAlternatives :: !(NonEmpty Match)
+  , caseSpan :: !SourceSpan
   } deriving (Show, Eq)
 
 data Match
@@ -164,6 +167,7 @@ data Let
   = Let
   { letBindings :: ![LetBinding]
   , letExpression :: !Expr
+  , letSpan :: !SourceSpan
   } deriving (Show, Eq)
 
 data LetBinding
@@ -178,6 +182,18 @@ letBinding _ = Nothing
 letBindingType :: LetBinding -> Maybe BindingType
 letBindingType (LetBindingType x) = Just x
 letBindingType _ = Nothing
+
+expressionSpan :: Expr -> SourceSpan
+expressionSpan (ELit (Located s _)) = s
+expressionSpan (ERecord _) = undefined
+expressionSpan (ERecordSelect expr (Located end _)) = mergeSpans (expressionSpan expr) end
+expressionSpan (EVar (VVal (Located s _))) = s
+expressionSpan (EVar (VCons (Located s _))) = s
+expressionSpan (EIf (If _ _ _ s)) = s
+expressionSpan (ECase (Case _ _ s)) = s
+expressionSpan (ELet (Let _ _ s)) = s
+expressionSpan (EApp e1 e2) = mergeSpans (expressionSpan e1) (expressionSpan e2)
+expressionSpan (EParens e) = expressionSpan e
 
 data Type
   = TyCon !(Located TyConName)

--- a/library/Amy/Syntax/Lexer.hs
+++ b/library/Amy/Syntax/Lexer.hs
@@ -55,7 +55,7 @@ lexeme p = do
   (SourcePos fp startLine startCol) <- getPosition
   val <- p
   (SourcePos _ endLine endCol) <- getPosition
-  spaceConsumer
+  spaceConsumerNewlines
   let
     sourceSpan =
       SourceSpan
@@ -110,32 +110,32 @@ reservedWords =
   , "in"
   ]
 
-extern :: AmyParser ()
-extern = void $ symbol "extern"
+extern :: AmyParser SourceSpan
+extern = fmap locatedSpan . lexeme $ symbol "extern"
 
-forall :: AmyParser ()
-forall = void $ symbol "forall"
+forall :: AmyParser SourceSpan
+forall = fmap locatedSpan . lexeme $ symbol "forall"
 
-if' :: AmyParser ()
-if' = void $ symbol "if"
+if' :: AmyParser SourceSpan
+if' = fmap locatedSpan . lexeme $ symbol "if"
 
-then' :: AmyParser ()
-then' = void $ symbol "then"
+then' :: AmyParser SourceSpan
+then' = fmap locatedSpan . lexeme $ symbol "then"
 
-else' :: AmyParser ()
-else' = void $ symbol "else"
+else' :: AmyParser SourceSpan
+else' = fmap locatedSpan . lexeme $ symbol "else"
 
-case' :: AmyParser ()
-case' = void $ symbol "case"
+case' :: AmyParser SourceSpan
+case' = fmap locatedSpan . lexeme $ symbol "case"
 
-of' :: AmyParser ()
-of' = void $ symbol "of"
+of' :: AmyParser SourceSpan
+of' = fmap locatedSpan . lexeme $ symbol "of"
 
-let' :: AmyParser ()
-let' = void $ symbol "let"
+let' :: AmyParser SourceSpan
+let' = fmap locatedSpan . lexeme $ symbol "let"
 
-in' :: AmyParser ()
-in' = void $ symbol "in"
+in' :: AmyParser SourceSpan
+in' = fmap locatedSpan . lexeme $ symbol "in"
 
 -- | Type names are upper-case, like Int and Double
 typeIdentifier :: AmyParser (Located Text)
@@ -153,14 +153,14 @@ tyVarName = fmap (TyVarName . unIdentName) <$> identifier
 rowLabel :: AmyParser (Located RowLabel)
 rowLabel = fmap (RowLabel . unIdentName) <$> identifier
 
-pipe :: AmyParser ()
-pipe = char '|' >> spaceConsumer
+pipe :: AmyParser SourceSpan
+pipe = fmap locatedSpan . lexeme $ char '|'
 
-lparen :: AmyParser ()
-lparen = char '(' >> spaceConsumer
+lparen :: AmyParser SourceSpan
+lparen = fmap locatedSpan . lexeme $ char '('
 
-rparen :: AmyParser ()
-rparen = char ')' >> spaceConsumer
+rparen :: AmyParser SourceSpan
+rparen = fmap locatedSpan . lexeme $ char ')'
 
 parens :: AmyParser a -> AmyParser a
 parens = between lparen rparen
@@ -168,37 +168,37 @@ parens = between lparen rparen
 optionalParens :: AmyParser a -> AmyParser a
 optionalParens p = parens p <|> p
 
-lbrace :: AmyParser ()
-lbrace = char '{' >> spaceConsumer
+lbrace :: AmyParser SourceSpan
+lbrace = fmap locatedSpan . lexeme $ char '{'
 
-rbrace :: AmyParser ()
-rbrace = char '}' >> spaceConsumer
+rbrace :: AmyParser SourceSpan
+rbrace = fmap locatedSpan . lexeme $ char '}'
 
 braces :: AmyParser a -> AmyParser a
 braces = between lbrace rbrace
 
-comma :: AmyParser ()
-comma = char ',' >> spaceConsumer
+comma :: AmyParser SourceSpan
+comma = fmap locatedSpan . lexeme $ char ','
 
-dot :: AmyParser ()
-dot = char '.' >> spaceConsumer
+dot :: AmyParser SourceSpan
+dot = fmap locatedSpan . lexeme $ char '.'
 
-colon :: AmyParser ()
-colon = char ':' >> spaceConsumer
+colon :: AmyParser SourceSpan
+colon = fmap locatedSpan . lexeme $ char ':'
 
-semiColon :: AmyParser ()
-semiColon = char ';' >> spaceConsumer
+semiColon :: AmyParser SourceSpan
+semiColon = fmap locatedSpan . lexeme $ char ';'
 
-doubleColon :: AmyParser ()
-doubleColon = char ':' >> char ':' >> spaceConsumer
+doubleColon :: AmyParser SourceSpan
+doubleColon = fmap locatedSpan . lexeme $ char ':' >> char ':'
 
-equals :: AmyParser ()
-equals = char '=' >> spaceConsumer
+equals :: AmyParser SourceSpan
+equals = fmap locatedSpan . lexeme $ char '='
 
-rightArrow :: AmyParser ()
-rightArrow = string "->" >> spaceConsumer
+rightArrow :: AmyParser SourceSpan
+rightArrow = fmap locatedSpan . lexeme $ string "->"
 
-typeSeparatorArrow :: AmyParser ()
+typeSeparatorArrow :: AmyParser SourceSpan
 typeSeparatorArrow = rightArrow
 
 text :: AmyParser Text

--- a/library/Amy/Syntax/Lexer.hs
+++ b/library/Amy/Syntax/Lexer.hs
@@ -22,8 +22,9 @@ module Amy.Syntax.Lexer
   , let'
   , in'
   , parens
-  , braces
   , optionalParens
+  , lbrace
+  , rbrace
   , comma
   , dot
   , colon
@@ -173,9 +174,6 @@ lbrace = fmap locatedSpan . lexeme $ char '{'
 
 rbrace :: AmyParser SourceSpan
 rbrace = fmap locatedSpan . lexeme $ char '}'
-
-braces :: AmyParser a -> AmyParser a
-braces = between lbrace rbrace
 
 comma :: AmyParser SourceSpan
 comma = fmap locatedSpan . lexeme $ char ','

--- a/library/Amy/Syntax/Located.hs
+++ b/library/Amy/Syntax/Located.hs
@@ -5,6 +5,7 @@
 module Amy.Syntax.Located
   ( Located(..)
   , SourceSpan(..)
+  , mergeSpans
   ) where
 
 -- | Location of something in source code.
@@ -23,3 +24,7 @@ data SourceSpan
   , sourceSpanEndLine :: !Int
   , sourceSpanEndColumn :: !Int
   } deriving (Show, Eq, Ord)
+
+mergeSpans :: SourceSpan -> SourceSpan -> SourceSpan
+mergeSpans (SourceSpan file startLine startCol _ _) (SourceSpan _ _ _ endLine endCol) =
+  SourceSpan file startLine startCol endLine endCol

--- a/library/Amy/Syntax/Monad.hs
+++ b/library/Amy/Syntax/Monad.hs
@@ -17,25 +17,25 @@ import Data.Text (Text, pack, unpack)
 import Data.Void (Void)
 import Text.Megaparsec hiding (State)
 
-newtype AmyParser a = AmyParser (StateT Pos (Parsec Void Text) a)
-  deriving (Functor, Applicative, Alternative, MonadPlus, Monad, MonadState Pos, MonadParsec Void Text)
+newtype AmyParser a = AmyParser (StateT Int (Parsec Void Text) a)
+  deriving (Functor, Applicative, Alternative, MonadPlus, Monad, MonadState Int, MonadParsec Void Text)
 
 runAmyParser :: AmyParser a -> Parsec Void Text a
-runAmyParser (AmyParser action) = evalStateT action (mkPos 1)
+runAmyParser (AmyParser action) = evalStateT action 0
 
 withBlockIndentation :: AmyParser a -> AmyParser a
 withBlockIndentation action = do
   originalIndent <- currentIndentation
   currentIndent <- sourceColumn <$> getPosition
-  setIndentation currentIndent
+  setIndentation (unPos currentIndent)
   result <- action
   setIndentation originalIndent
   pure result
 
-currentIndentation :: AmyParser Pos
+currentIndentation :: AmyParser Int
 currentIndentation = get
 
-setIndentation :: Pos -> AmyParser ()
+setIndentation :: Int -> AmyParser ()
 setIndentation x = modify' (const x)
 
 -- | Check that the current indentation level is past the stored indentation
@@ -49,9 +49,9 @@ assertSameIndentation = checkIndentation "indentation at column" (==)
 -- | Check that the current identation level matches a predicate
 checkIndentation
   :: Text
-  -> (Pos -> Pos -> Bool)
+  -> (Int -> Int -> Bool)
   -> AmyParser ()
 checkIndentation msg rel = do
-  col <- sourceColumn <$> getPosition
+  col <- unPos . sourceColumn <$> getPosition
   current <- currentIndentation
-  guard (col `rel` current) <?> unpack (msg <> " " <> pack (show $ unPos current))
+  guard (col `rel` current) <?> unpack (msg <> " " <> pack (show current))

--- a/library/Amy/Syntax/Parser.hs
+++ b/library/Amy/Syntax/Parser.hs
@@ -31,9 +31,11 @@ import Amy.Syntax.Located
 import Amy.Syntax.Monad
 
 parseModule :: AmyParser Module
-parseModule = Module <$> do
+parseModule = do
   spaceConsumerNewlines
-  noIndent (indentedBlock declaration) <* eof
+  declarations <- noIndent (indentedBlock declaration) <* eof
+  fileName <- sourceName <$> getPosition
+  pure $ Module fileName declarations
 
 declaration :: AmyParser Declaration
 declaration =

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -67,13 +67,13 @@ prettyExpr (ELit (Located _ lit)) = pretty $ showLiteral lit
 prettyExpr (ERecord rows) = bracketed $ uncurry prettyRow <$> Map.toList rows
 prettyExpr (ERecordSelect expr field) = prettyExpr expr <> "." <> prettyRowLabel (locatedValue field)
 prettyExpr (EVar var) = prettyVar var
-prettyExpr (EIf (If pred' then' else')) =
+prettyExpr (EIf (If pred' then' else' _)) =
   prettyIf (prettyExpr pred') (prettyExpr then') (prettyExpr else')
-prettyExpr (ECase (Case scrutinee matches)) =
+prettyExpr (ECase (Case scrutinee matches _)) =
   prettyCase (prettyExpr scrutinee) Nothing (toList $ mkMatch <$> matches)
  where
   mkMatch (Match pat body) = (prettyPattern pat, prettyExpr body)
-prettyExpr (ELet (Let bindings body)) =
+prettyExpr (ELet (Let bindings body _)) =
   prettyLet (prettyLetBinding <$> bindings) (prettyExpr body)
  where
   prettyLetBinding (LetBinding binding) = prettyBinding' binding

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -50,7 +50,7 @@ prettyDeclaration (DeclType (TypeDeclaration info cons)) =
     prettyDataConstructor (prettyDataConName conName) (prettyType <$> mArg)
 
 prettyTyConDefinition :: TyConDefinition -> Doc ann
-prettyTyConDefinition (TyConDefinition name args _) = prettyTyConName name <> args'
+prettyTyConDefinition (TyConDefinition (Located _ name) args) = prettyTyConName name <> args'
  where
   args' = if null args then mempty else space <> sep (prettyTyVarName . locatedValue <$> args)
 
@@ -64,7 +64,7 @@ prettyBindingType' (BindingType (Located _ name) ty) =
 
 prettyExpr :: Expr -> Doc ann
 prettyExpr (ELit (Located _ lit)) = pretty $ showLiteral lit
-prettyExpr (ERecord rows) = bracketed $ uncurry prettyRow <$> Map.toList rows
+prettyExpr (ERecord _ rows) = bracketed $ uncurry prettyRow <$> Map.toList rows
 prettyExpr (ERecordSelect expr field) = prettyExpr expr <> "." <> prettyRowLabel (locatedValue field)
 prettyExpr (EVar var) = prettyVar var
 prettyExpr (EIf (If pred' then' else' _)) =

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -36,7 +36,7 @@ isTyFun TyFun{} = True
 isTyFun _ = False
 
 prettyModule :: Module -> Doc ann
-prettyModule (Module decls) = vcatTwoHardLines (prettyDeclaration <$> decls)
+prettyModule (Module _ decls) = vcatTwoHardLines (prettyDeclaration <$> decls)
 
 prettyDeclaration :: Declaration -> Doc ann
 prettyDeclaration (DeclBinding binding) = prettyBinding' binding

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -6,9 +6,7 @@ module Amy.TypeCheck.AST
   , Extern(..)
   , TypeDeclaration(..)
   , TyConDefinition(..)
-  , fromPrimTypeDef
   , DataConDefinition(..)
-  , fromPrimDataCon
   , Expr(..)
   , Var(..)
   , If(..)
@@ -81,21 +79,11 @@ data TyConDefinition
   , tyConDefinitionArgs :: ![TyVarName]
   } deriving (Show, Eq, Ord)
 
-fromPrimTyDef :: TyConName -> TyConDefinition
-fromPrimTyDef name = TyConDefinition name []
-
-fromPrimTypeDef :: PrimTypeDefinition -> TypeDeclaration
-fromPrimTypeDef (PrimTypeDefinition tyCon dataCons) =
-  TypeDeclaration (fromPrimTyDef tyCon) (fromPrimDataCon <$> dataCons)
-
 data DataConDefinition
   = DataConDefinition
   { dataConDefinitionName :: !DataConName
   , dataConDefinitionArgument :: !(Maybe Type)
   } deriving (Show, Eq, Ord)
-
-fromPrimDataCon :: DataConName -> DataConDefinition
-fromPrimDataCon name = DataConDefinition name Nothing
 
 -- | A renamed 'Expr'
 data Expr

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -6,7 +6,7 @@ module Amy.TypeCheck.KindInference
   , inferTypeKind
   ) where
 
-import Control.Monad.Except
+import Control.Monad (when)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -127,12 +127,12 @@ unifyKinds (KFun k1 k2) (KFun k3 k4) = do
   su1 <- unifyKinds k1 k3
   su2 <- unifyKinds (substituteKind su1 k2) (substituteKind su1 k4)
   pure (su2 `composeSubst` su1)
-unifyKinds k1 k2 = throwError $ KindUnificationFail k1 k2
+unifyKinds k1 k2 = throwAmyError $ KindUnificationFail k1 k2
 
 bind :: Int -> Kind -> Checker Subst
 bind i k
   | k == KUnknown i = pure emptySubst
-  | occursCheck i k = throwError $ InfiniteKind i k
+  | occursCheck i k = throwAmyError $ InfiniteKind i k
   | otherwise = pure (singletonSubst i k)
 
 occursCheck :: Int -> Kind -> Bool

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -18,6 +18,7 @@ module Amy.TypeCheck.Monad
   , freshTyExistVarNoContext
   , freshTyExistVar
   , freshTyExistMarkerVar
+  , withSourceSpan
   , throwAmyError
   , getContext
   , putContext
@@ -202,6 +203,14 @@ freshTyExistMarkerVar = do
   var <- freshTyExistVarNoContext
   modifyContext (|> ContextMarker var)
   pure var
+
+withSourceSpan :: SourceSpan -> Checker a -> Checker a
+withSourceSpan span' action = do
+  orig <- gets sourceSpan
+  modify' $ \s -> s { sourceSpan = span' }
+  result <- action
+  modify' $ \s -> s { sourceSpan = orig }
+  pure result
 
 throwAmyError :: ErrorMessage -> Checker a
 throwAmyError message = do

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -118,7 +118,7 @@ contextUnsolved (Context context) = mapMaybe getEVar $ toList context
 contextUntil :: ContextMember -> Context -> Context
 contextUntil member (Context context) = Context $ Seq.takeWhileL (/= member) context
 
-typeWellFormed :: Context -> Type -> Maybe Error
+typeWellFormed :: Context -> Type -> Maybe ErrorMessage
 typeWellFormed _ (TyCon _) = Nothing
 typeWellFormed context (TyVar v) = do
   guard $ not $ ContextVar v `contextElem` context
@@ -140,8 +140,8 @@ typeWellFormed context (TyForall vs t) = typeWellFormed (context <> Context (Seq
 
 -- TODO: Use Validation instead of ExceptT
 
-newtype Checker a = Checker (ExceptT Error (State CheckState) a)
-  deriving (Functor, Applicative, Monad, MonadState CheckState, MonadError Error)
+newtype Checker a = Checker (ExceptT ErrorMessage (State CheckState) a)
+  deriving (Functor, Applicative, Monad, MonadState CheckState, MonadError ErrorMessage)
 
 data CheckState
   = CheckState
@@ -156,7 +156,7 @@ data CheckState
 runChecker
   :: [(IdentName, Type)]
   -> [(DataConName, Type)]
-  -> Checker a -> Either Error a
+  -> Checker a -> Either ErrorMessage a
 runChecker identTypes dataConTypes (Checker action) = do
   -- Check for duplicate data con names
   for_ groupedConNames $ \nameGroup ->
@@ -266,7 +266,7 @@ insertMapDuplicateError
   -> (CheckState -> Map k v -> CheckState)
   -> k
   -> v
-  -> (k -> Error)
+  -> (k -> ErrorMessage)
   -> Checker ()
 insertMapDuplicateError getMap putMap name value mkError = do
   theMap <- gets getMap

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -163,7 +163,7 @@ inferExpr (S.EVar var) =
       withSourceSpan span' $ do
         t <- currentContextSubst =<< lookupDataConType con
         pure (T.EVar $ T.VCons (T.Typed t con))
-inferExpr (S.EIf (S.If pred' then' else')) = do
+inferExpr (S.EIf (S.If pred' then' else' _)) = do
   -- TODO: Is this the right way to do this? Should we actually infer the types
   -- and then unify with expected types? I'm thinking instead we should
   -- instantiate a variable for then/else and check both of them against it,
@@ -172,7 +172,7 @@ inferExpr (S.EIf (S.If pred' then' else')) = do
   then'' <- inferExpr then'
   else'' <- checkExpr else' (expressionType then'')
   pure $ T.EIf $ T.If pred'' then'' else''
-inferExpr (S.ELet (S.Let bindings expression)) = do
+inferExpr (S.ELet (S.Let bindings expression _)) = do
   let
     bindings' = mapMaybe letBinding bindings
     bindingTypes = mapMaybe letBindingType bindings
@@ -200,7 +200,7 @@ inferExpr (S.ERecordSelect expr (Located span' label)) = do
   retTy <- currentContextSubst $ T.TyExistVar retVar
   pure $ T.ERecordSelect expr' label retTy
 inferExpr (S.EParens expr) = T.EParens <$> inferExpr expr
-inferExpr (S.ECase (S.Case scrutinee matches)) = do
+inferExpr (S.ECase (S.Case scrutinee matches _)) = do
   scrutineeVar <- freshTyExistVar
   matchVar <- freshTyExistVar
   scrutinee' <- checkExpr scrutinee (T.TyExistVar scrutineeVar)

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -276,14 +276,14 @@ checkBinding :: S.Binding -> T.Type -> Checker T.Binding
 checkBinding binding (T.TyForall as t) =
   withContextUntilNE (ContextVar <$> as) $
     checkBinding binding t
-checkBinding binding@(S.Binding (Located span' name) args body) t =
+checkBinding (S.Binding (Located span' name) args body) t =
   withSourceSpan span' $ do
     -- Split out argument and body types
     let
       unfoldedTy = unfoldTyFun t
       numArgs = length args
     when (length unfoldedTy < numArgs + 1) $
-      throwAmyError $ TooManyBindingArguments binding
+      throwAmyError $ TooManyBindingArguments (length unfoldedTy - 1) numArgs
     let
       (argTys, bodyTys) = NE.splitAt numArgs unfoldedTy
       bodyTy = foldr1 T.TyFun bodyTys

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -40,8 +40,8 @@ inferModule (S.Module declarations) = do
     bindingTypes = mapMaybe declBindingType declarations
 
     externs' = convertExtern <$> externs
+    allTypeDeclarations = allPrimTypeDefinitions ++ typeDeclarations
     typeDeclarations' = convertTypeDeclaration <$> typeDeclarations
-    primTypeDeclarations = convertTypeDeclaration <$> allPrimTypeDefinitions
 
     externTypes = (\(T.Extern name ty) -> (name, ty)) <$> externs'
     primFuncTypes = primitiveFunctionType' <$> allPrimitiveFunctions
@@ -49,8 +49,8 @@ inferModule (S.Module declarations) = do
     dataConstructorTypes = concatMap mkDataConTypes (allPrimTypeDefinitions ++ typeDeclarations)
   runChecker identTypes dataConstructorTypes "TODO" $ do
     -- Infer type declaration kinds and add to scope
-    for_ (primTypeDeclarations ++ typeDeclarations') $ \decl@(T.TypeDeclaration (T.TyConDefinition tyCon _) _) -> do
-      kind <- inferTypeDeclarationKind decl
+    for_ allTypeDeclarations $ \decl@(S.TypeDeclaration (S.TyConDefinition tyCon _) _) -> do
+      kind <- inferTypeDeclarationKind (convertTypeDeclaration decl)
       addTyConKindToScope tyCon kind
 
     -- Infer all bindings
@@ -63,18 +63,17 @@ inferBindingGroup isTopLevel bindings bindingTypes = do
     bindingTypeMap = Map.fromList $ (\(BindingType (Located _ name) ty) -> (name, ty)) <$> bindingTypes
 
   -- Add all binding group types to context
-  bindingsWithTypes <- for bindings $ \binding@(S.Binding (Located span' name) _ _) ->
-    withSourceSpan span' $ do
-      let mTy = Map.lookup name bindingTypeMap
-      ty <-
-        case mTy of
-          Just ty' -> do
-            let ty'' = convertType ty'
-            checkTypeKind ty''
-            pure ty''
-          Nothing -> T.TyExistVar <$> freshTyExistVar
-      addValueTypeToScope name ty
-      pure (binding, ty)
+  bindingsWithTypes <- for bindings $ \binding@(S.Binding lname@(Located _ name) _ _) -> do
+    let mTy = Map.lookup name bindingTypeMap
+    ty <-
+      case mTy of
+        Just ty' -> do
+          let ty'' = convertType ty'
+          checkTypeKind ty''
+          pure ty''
+        Nothing -> T.TyExistVar <$> freshTyExistVar
+    addValueTypeToScope lname ty
+    pure (binding, ty)
 
   -- Infer each binding individually
   bindings' <- for bindingsWithTypes $ \(binding, ty) ->
@@ -102,18 +101,16 @@ inferBindingGroup isTopLevel bindings bindingTypes = do
       contextSubstBinding context' $ binding { T.bindingType = ty' }
 
 inferBinding :: S.Binding -> Checker T.Binding
-inferBinding (S.Binding (Located nameSpan name) args body) = withNewLexicalScope $ do
-  argsAndVars <- for args $ \(Located argSpan arg) ->
-    withSourceSpan argSpan $ do
-      ty <- freshTyExistVar
-      addValueTypeToScope arg (TyExistVar ty)
-      pure (arg, ty)
+inferBinding (S.Binding (Located nameSpan name) args body) = withSourceSpan nameSpan $ withNewLexicalScope $ do
+  argsAndVars <- for args $ \larg@(Located _ arg) -> do
+    ty <- freshTyExistVar
+    addValueTypeToScope larg (TyExistVar ty)
+    pure (arg, ty)
   bodyVar <- freshTyExistVar
   marker <- freshTyExistMarkerVar
 
   -- Infer body
-  body' <- withSourceSpan nameSpan $
-    checkExpr body (TyExistVar bodyVar)
+  body' <- checkExpr body (TyExistVar bodyVar)
 
   -- Construct the type from arg/body variables
   let ty = foldr1 T.TyFun $ T.TyExistVar <$> ((snd <$> argsAndVars) ++ [bodyVar])
@@ -152,18 +149,19 @@ letters :: [Text]
 letters = [1..] >>= fmap pack . flip replicateM ['a'..'z']
 
 inferExpr :: S.Expr -> Checker T.Expr
-inferExpr (S.ELit (Located _ lit)) = pure $ T.ELit lit
-inferExpr (S.EVar var) =
+inferExpr expr = withSourceSpan (expressionSpan expr) $ inferExpr' expr
+
+inferExpr' :: S.Expr -> Checker T.Expr
+inferExpr' (S.ELit (Located _ lit)) = pure $ T.ELit lit
+inferExpr' (S.EVar var) =
   case var of
-    S.VVal (Located span' valVar) ->
-      withSourceSpan span' $ do
-        t <- currentContextSubst =<< lookupValueType valVar
-        pure $ T.EVar $ T.VVal (T.Typed t valVar)
-    S.VCons (Located span' con) ->
-      withSourceSpan span' $ do
-        t <- currentContextSubst =<< lookupDataConType con
-        pure (T.EVar $ T.VCons (T.Typed t con))
-inferExpr (S.EIf (S.If pred' then' else' _)) = do
+    S.VVal lvar@(Located _ valVar) -> do
+      t <- currentContextSubst =<< lookupValueType lvar
+      pure $ T.EVar $ T.VVal (T.Typed t valVar)
+    S.VCons lcon@(Located _ con) -> do
+      t <- currentContextSubst =<< lookupDataConType lcon
+      pure (T.EVar $ T.VCons (T.Typed t con))
+inferExpr' (S.EIf (S.If pred' then' else' _)) = do
   -- TODO: Is this the right way to do this? Should we actually infer the types
   -- and then unify with expected types? I'm thinking instead we should
   -- instantiate a variable for then/else and check both of them against it,
@@ -172,7 +170,7 @@ inferExpr (S.EIf (S.If pred' then' else' _)) = do
   then'' <- inferExpr then'
   else'' <- checkExpr else' (expressionType then'')
   pure $ T.EIf $ T.If pred'' then'' else''
-inferExpr (S.ELet (S.Let bindings expression _)) = do
+inferExpr' (S.ELet (S.Let bindings expression _)) = do
   let
     bindings' = mapMaybe letBinding bindings
     bindingTypes = mapMaybe letBindingType bindings
@@ -180,27 +178,25 @@ inferExpr (S.ELet (S.Let bindings expression _)) = do
     bindings'' <- inferBindingGroup False bindings' bindingTypes
     expression' <- inferExpr expression
     pure $ T.ELet (T.Let bindings'' expression')
-inferExpr (S.EApp f e) = do
+inferExpr' (S.EApp f e) = do
   f' <- inferExpr f
   tfSub <- currentContextSubst (expressionType f')
   (e', retTy) <- inferApp tfSub e
   pure (T.EApp $ T.App f' e' retTy)
-inferExpr (S.ERecord rows) = do
-  rows' <- fmap Map.fromList $ for (Map.toList rows) $ \(Located span' label, expr) ->
-    withSourceSpan span' $ do
-      expr' <- inferExpr expr
-      pure (label, T.Typed (expressionType expr') expr')
+inferExpr' (S.ERecord _ rows) = do
+  rows' <- fmap Map.fromList $ for (Map.toList rows) $ \(Located _ label, expr) -> do
+    expr' <- inferExpr expr
+    pure (label, T.Typed (expressionType expr') expr')
   pure $ T.ERecord rows'
-inferExpr (S.ERecordSelect expr (Located span' label)) = do
+inferExpr' (S.ERecordSelect expr (Located _ label)) = do
   retVar <- freshTyExistVar
   polyVar <- freshTyExistVar
   let exprTy = T.TyRecord (Map.singleton label $ T.TyExistVar retVar) (Just $ T.TyExistVar polyVar)
-  expr' <- withSourceSpan span' $
-    checkExpr expr exprTy
+  expr' <- checkExpr expr exprTy
   retTy <- currentContextSubst $ T.TyExistVar retVar
   pure $ T.ERecordSelect expr' label retTy
-inferExpr (S.EParens expr) = T.EParens <$> inferExpr expr
-inferExpr (S.ECase (S.Case scrutinee matches _)) = do
+inferExpr' (S.EParens expr) = T.EParens <$> inferExpr expr
+inferExpr' (S.ECase (S.Case scrutinee matches _)) = do
   scrutineeVar <- freshTyExistVar
   matchVar <- freshTyExistVar
   scrutinee' <- checkExpr scrutinee (T.TyExistVar scrutineeVar)
@@ -224,37 +220,51 @@ inferApp (T.TyFun t1 t2) e = do
 inferApp t e = error $ "Cannot inferApp for " ++ show (t, e)
 
 inferMatch :: T.Type ->  S.Match -> Checker T.Match
-inferMatch scrutineeTy (S.Match pat body) = do
-  pat' <- checkPattern pat scrutineeTy
-  body' <- withNewLexicalScope $ do
-    traverse_ (uncurry addValueTypeToScope) (patternBinderType pat')
-    inferExpr body
-  pure $ T.Match pat' body'
+inferMatch scrutineeTy match@(S.Match pat body) =
+  withSourceSpan (matchSpan match) $ do
+    pat' <- checkPattern pat scrutineeTy
+    body' <- withNewLexicalScope $ do
+      let
+        mBinderNameAndTy = do
+          ident <- patternBinderIdent pat
+          ty <- patternBinderType pat'
+          pure (ident, ty)
+      traverse_ (uncurry addValueTypeToScope) mBinderNameAndTy
+      inferExpr body
+    pure $ T.Match pat' body'
 
 inferPattern :: S.Pattern -> Checker T.Pattern
-inferPattern (S.PLit (Located _ lit)) = pure $ T.PLit lit
-inferPattern (S.PVar (Located _ ident)) = do
+inferPattern pat = withSourceSpan (patternSpan pat) $ inferPattern' pat
+
+inferPattern' :: S.Pattern -> Checker T.Pattern
+inferPattern' (S.PLit (Located _ lit)) = pure $ T.PLit lit
+inferPattern' (S.PVar (Located _ ident)) = do
   tvar <- freshTyExistVar
   pure $ T.PVar $ T.Typed (T.TyExistVar tvar) ident
-inferPattern (S.PCons (S.PatCons (Located span' con) mArg)) =
-  withSourceSpan span' $ do
-    conTy <- currentContextSubst =<< lookupDataConType con
-    case mArg of
-      -- Convert argument and add a constraint on argument plus constructor
-      Just arg -> do
-        arg' <- inferPattern arg
-        let argTy = patternType arg'
-        retTy <- freshTyExistVar
-        subtype conTy (argTy `T.TyFun` T.TyExistVar retTy) -- Is this right?
-        pure $ T.PCons $ T.PatCons con (Just arg') (T.TyExistVar retTy)
-      -- No argument. The return type is just the data constructor type.
-      Nothing ->
-        pure $ T.PCons $ T.PatCons con Nothing conTy
-inferPattern (S.PParens pat) = T.PParens <$> inferPattern pat
+inferPattern' (S.PCons (S.PatCons lcon@(Located _ con) mArg)) = do
+  conTy <- currentContextSubst =<< lookupDataConType lcon
+  case mArg of
+    -- Convert argument and add a constraint on argument plus constructor
+    Just arg -> do
+      arg' <- inferPattern arg
+      let argTy = patternType arg'
+      retTy <- freshTyExistVar
+      subtype conTy (argTy `T.TyFun` T.TyExistVar retTy) -- Is this right?
+      pure $ T.PCons $ T.PatCons con (Just arg') (T.TyExistVar retTy)
+    -- No argument. The return type is just the data constructor type.
+    Nothing ->
+      pure $ T.PCons $ T.PatCons con Nothing conTy
+inferPattern' (S.PParens pat) = T.PParens <$> inferPattern pat
 
-patternBinderType :: T.Pattern -> Maybe (IdentName, T.Type)
+patternBinderIdent :: S.Pattern -> Maybe (Located IdentName)
+patternBinderIdent (S.PLit _) = Nothing
+patternBinderIdent (S.PVar ident) = Just ident
+patternBinderIdent (S.PCons (S.PatCons _ mArg)) = patternBinderIdent =<< mArg
+patternBinderIdent (S.PParens pat) = patternBinderIdent pat
+
+patternBinderType :: T.Pattern -> Maybe T.Type
 patternBinderType (T.PLit _) = Nothing
-patternBinderType (T.PVar (T.Typed ty ident)) = Just (ident, ty)
+patternBinderType (T.PVar (T.Typed ty _)) = Just ty
 patternBinderType (T.PCons (T.PatCons _ mArg _)) = patternBinderType =<< mArg
 patternBinderType (T.PParens pat) = patternBinderType pat
 
@@ -280,10 +290,9 @@ checkBinding binding@(S.Binding (Located span' name) args body) t =
 
     withNewLexicalScope $ withNewContextScope $ do
       -- Add argument types to scope
-      args' <- for (zip args argTys) $ \(Located argSpan arg, ty) ->
-        withSourceSpan argSpan $ do
-          addValueTypeToScope arg ty
-          pure $ Typed ty arg
+      args' <- for (zip args argTys) $ \(larg@(Located _ arg), ty) -> do
+        addValueTypeToScope larg ty
+        pure $ Typed ty arg
 
       -- Check body
       body' <- checkExpr body bodyTy
@@ -293,10 +302,13 @@ checkBinding binding@(S.Binding (Located span' name) args body) t =
       pure $ contextSubstBinding context $ T.Binding name t args' bodyTy body'
 
 checkExpr :: S.Expr -> T.Type -> Checker T.Expr
-checkExpr e (T.TyForall as t) =
+checkExpr e t = withSourceSpan (expressionSpan e) $ checkExpr' e t
+
+checkExpr' :: S.Expr -> T.Type -> Checker T.Expr
+checkExpr' e (T.TyForall as t) =
   withContextUntilNE (ContextVar <$> as) $
     checkExpr e t
-checkExpr e t = do
+checkExpr' e t = do
   e' <- inferExpr e
   tSub <- currentContextSubst t
   eTy' <- currentContextSubst $ expressionType e'
@@ -304,20 +316,22 @@ checkExpr e t = do
   pure e'
 
 checkMatch :: T.Type -> S.Match -> T.Type -> Checker T.Match
-checkMatch scrutineeTy m t = do
-  m' <- inferMatch scrutineeTy m
-  tSub <- currentContextSubst t
-  mTy' <- currentContextSubst $ matchType m'
-  subtype mTy' tSub
-  pure m'
+checkMatch scrutineeTy m t =
+  withSourceSpan (matchSpan m) $ do
+    m' <- inferMatch scrutineeTy m
+    tSub <- currentContextSubst t
+    mTy' <- currentContextSubst $ matchType m'
+    subtype mTy' tSub
+    pure m'
 
 checkPattern :: S.Pattern -> T.Type -> Checker T.Pattern
-checkPattern pat t = do
-  pat' <- inferPattern pat
-  tSub <- currentContextSubst t
-  patTy' <- currentContextSubst $ patternType pat'
-  subtype patTy' tSub
-  pure pat'
+checkPattern pat t =
+  withSourceSpan (patternSpan pat) $ do
+    pat' <- inferPattern pat
+    tSub <- currentContextSubst t
+    patTy' <- currentContextSubst $ patternType pat'
+    subtype patTy' tSub
+    pure pat'
 
 --
 -- Converting types
@@ -344,7 +358,7 @@ convertDataConDefinition (S.DataConDefinition (Located _ conName) mTyArg) =
   }
 
 mkDataConTypes :: S.TypeDeclaration -> [(Located DataConName, T.Type)]
-mkDataConTypes (S.TypeDeclaration (S.TyConDefinition tyConName tyVars _) dataConDefs) = mkDataConPair <$> dataConDefs
+mkDataConTypes (S.TypeDeclaration (S.TyConDefinition (Located _ tyConName) tyVars) dataConDefs) = mkDataConPair <$> dataConDefs
  where
   mkDataConPair (S.DataConDefinition name mTyArg) =
     let
@@ -367,7 +381,7 @@ convertType (S.TyFun ty1 ty2) = T.TyFun (convertType ty1) (convertType ty2)
 convertType (S.TyForall vars ty) = T.TyForall (convertTyVarInfo <$> vars) (convertType ty)
 
 convertTyConDefinition :: S.TyConDefinition -> T.TyConDefinition
-convertTyConDefinition (S.TyConDefinition name' args _) = T.TyConDefinition name' (locatedValue <$> args)
+convertTyConDefinition (S.TyConDefinition (Located _ name') args) = T.TyConDefinition name' (locatedValue <$> args)
 
 convertTyVarInfo :: Located TyVarName -> T.TyVarName
 convertTyVarInfo (Located _ name') = name'

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -31,7 +31,7 @@ import Amy.TypeCheck.Subtyping
 -- Infer
 --
 
-inferModule :: S.Module -> Either Error T.Module
+inferModule :: S.Module -> Either ErrorMessage T.Module
 inferModule (S.Module declarations) = do
   let
     typeDeclarations = mapMaybe declType declarations

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -32,7 +32,7 @@ import Amy.TypeCheck.Subtyping
 --
 
 inferModule :: S.Module -> Either Error T.Module
-inferModule (S.Module declarations) = do
+inferModule (S.Module filePath declarations) = do
   let
     typeDeclarations = mapMaybe declType declarations
     externs = mapMaybe declExtern declarations
@@ -47,7 +47,7 @@ inferModule (S.Module declarations) = do
     primFuncTypes = primitiveFunctionType' <$> allPrimitiveFunctions
     identTypes = externTypes ++ primFuncTypes
     dataConstructorTypes = concatMap mkDataConTypes (allPrimTypeDefinitions ++ typeDeclarations)
-  runChecker identTypes dataConstructorTypes "TODO" $ do
+  runChecker identTypes dataConstructorTypes filePath $ do
     -- Infer type declaration kinds and add to scope
     for_ allTypeDeclarations $ \decl@(S.TypeDeclaration (S.TyConDefinition tyCon _) _) -> do
       kind <- inferTypeDeclarationKind (convertTypeDeclaration decl)

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -31,7 +31,7 @@ import Amy.TypeCheck.Subtyping
 -- Infer
 --
 
-inferModule :: S.Module -> Either ErrorMessage T.Module
+inferModule :: S.Module -> Either Error T.Module
 inferModule (S.Module declarations) = do
   let
     typeDeclarations = mapMaybe declType declarations
@@ -46,7 +46,7 @@ inferModule (S.Module declarations) = do
     primFuncTypes = primitiveFunctionType' <$> allPrimitiveFunctions
     identTypes = externTypes ++ primFuncTypes
     dataConstructorTypes = concatMap mkDataConTypes typeDeclarations'
-  runChecker identTypes dataConstructorTypes $ do
+  runChecker identTypes dataConstructorTypes "TODO" $ do
     -- Infer type declaration kinds and add to scope
     for_ typeDeclarations' $ \decl@(T.TypeDeclaration (T.TyConDefinition tyCon _) _) -> do
       kind <- inferTypeDeclarationKind decl
@@ -263,7 +263,7 @@ checkBinding binding@(S.Binding (Located _ name) args body) t = do
     unfoldedTy = unfoldTyFun t
     numArgs = length args
   when (length unfoldedTy < numArgs + 1) $
-    throwError $ TooManyBindingArguments binding
+    throwAmyError $ TooManyBindingArguments binding
   let
     (argTys, bodyTys) = NE.splitAt numArgs unfoldedTy
     bodyTy = foldr1 T.TyFun bodyTys

--- a/tests/Amy/Syntax/ParserSpec.hs
+++ b/tests/Amy/Syntax/ParserSpec.hs
@@ -178,12 +178,14 @@ spec = do
           (EVar (VCons $ Located (SourceSpan "" 1 4 1 7) "True"))
           (ELit (Located (SourceSpan "" 1 14 1 14) (LiteralInt 1)))
           (ELit (Located (SourceSpan "" 1 21 1 21) (LiteralInt 2)))
+          (SourceSpan "" 1 1 1 21)
       parse' ifExpression "if f x then f y else g 2"
         `shouldParse`
         If
           (EApp (EVar (VVal $ Located (SourceSpan "" 1 4 1 4) "f")) (EVar (VVal $ Located (SourceSpan "" 1 6 1 6) "x")))
           (EApp (EVar (VVal $ Located (SourceSpan "" 1 13 1 13) "f")) (EVar (VVal $ Located (SourceSpan "" 1 15 1 15) "y")))
           (EApp (EVar (VVal $ Located (SourceSpan "" 1 22 1 22) "g")) (ELit (Located (SourceSpan "" 1 24 1 24) (LiteralInt 2))))
+          (SourceSpan "" 1 1 1 24)
 
   describe "literal" $ do
     it "can discriminate between integer and double" $ do


### PR DESCRIPTION
This ended up being quite a bit more surgery than I intended so support getting `SourceSpan` in more parts of the AST. Luckily the often-touted benefit of bidirectional type checkers producing good error messages easily bore fruit here. I just choose the `SourceSpan` for the current expression in the `check`/`infer` functions, throw errors like normal, and the `SourceSpan` gets tacked on.

I'm also starting to think we need `SourceSpan`s in the type checked AST. That would remove some kludges I made where we are working on the type checked AST but we need the source span from the original Syntax AST. Also, if we throw warnings during Core translation (like redundant/inexhaustive checks while desugaring nested patterns), we'll need those source spans.