### PR TITLE
Build working executables with clang

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -25,7 +25,9 @@ RUN \
   echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" >> /etc/apt/sources.list.d/llvm.list && \
   apt-get update && \
   apt-get install -y --allow-unauthenticated \
+    clang-6.0 \
     llvm-6.0-dev && \
+  ln -s /usr/bin/clang-6.0 /usr/bin/clang && \
   rm -rf /var/lib/apt/lists/*
 
 # Install stack

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *.cabal
+a.out

--- a/package.yaml
+++ b/package.yaml
@@ -45,4 +45,5 @@ executables:
       - megaparsec
       - mtl
       - optparse-applicative
+      - process
       - text


### PR DESCRIPTION
This is fairly simple, but I opened a PR in case CircleCI needs coercing :smile: 

This is part of an effort to add a garbage collector. We will definitely need to link in C code for that, so the days of just running `lli` for tests are numbered.