### PR TITLE
Use malloc instead of alloca by default

### DIFF
--- a/integration-tests/pass/data/data.ll
+++ b/integration-tests/pass/data/data.ll
@@ -4,63 +4,74 @@ source_filename = "<string>"
 %MySum = type { i8, i64* }
 %Nat = type { i1, i64* }
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
-  %x = alloca %MySum
-  %0 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  store i8 1, i8* %0
-  %1 = alloca double
-  store double 0x401F333333333333, double* %1
-  %2 = bitcast double* %1 to i64*
-  %3 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  store i64* %2, i64** %3
-  %4 = alloca i8
-  store i8 1, i8* %4
-  %y = load i8, i8* %4
-  %z1 = alloca %Nat
-  %5 = getelementptr %Nat, %Nat* %z1, i32 0, i32 0
-  store i1 false, i1* %5
-  %z2 = alloca %Nat
-  %6 = getelementptr %Nat, %Nat* %z2, i32 0, i32 0
-  store i1 true, i1* %6
-  %7 = bitcast %Nat* %z1 to i64*
-  %8 = getelementptr %Nat, %Nat* %z2, i32 0, i32 1
-  store i64* %7, i64** %8
-  %z = alloca %Nat
-  %9 = getelementptr %Nat, %Nat* %z, i32 0, i32 0
-  store i1 true, i1* %9
-  %10 = bitcast %Nat* %z2 to i64*
-  %11 = getelementptr %Nat, %Nat* %z, i32 0, i32 1
-  store i64* %10, i64** %11
-  %12 = getelementptr %MySum, %MySum* %x, i32 0, i32 0
-  %13 = load i8, i8* %12
-  %14 = getelementptr %MySum, %MySum* %x, i32 0, i32 1
-  %15 = load i64*, i64** %14
-  switch i8 %13, label %case.0.ret [
+  %0 = call i8* @malloc(i64 ptrtoint (%MySum* getelementptr (%MySum, %MySum* null, i32 1) to i64))
+  %x = bitcast i8* %0 to %MySum*
+  %x1 = alloca %MySum
+  %1 = getelementptr %MySum, %MySum* %x1, i32 0, i32 0
+  store i8 1, i8* %1
+  %2 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %3 = bitcast i8* %2 to double*
+  store double 0x401F333333333333, double* %3
+  %4 = bitcast double* %3 to i64*
+  %5 = getelementptr %MySum, %MySum* %x1, i32 0, i32 1
+  store i64* %4, i64** %5
+  %6 = alloca i8
+  store i8 1, i8* %6
+  %y = load i8, i8* %6
+  %7 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z1 = bitcast i8* %7 to %Nat*
+  %z12 = alloca %Nat
+  %8 = getelementptr %Nat, %Nat* %z12, i32 0, i32 0
+  store i1 false, i1* %8
+  %9 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z2 = bitcast i8* %9 to %Nat*
+  %z23 = alloca %Nat
+  %10 = getelementptr %Nat, %Nat* %z23, i32 0, i32 0
+  store i1 true, i1* %10
+  %11 = bitcast %Nat* %z12 to i64*
+  %12 = getelementptr %Nat, %Nat* %z23, i32 0, i32 1
+  store i64* %11, i64** %12
+  %13 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z = bitcast i8* %13 to %Nat*
+  %z4 = alloca %Nat
+  %14 = getelementptr %Nat, %Nat* %z4, i32 0, i32 0
+  store i1 true, i1* %14
+  %15 = bitcast %Nat* %z23 to i64*
+  %16 = getelementptr %Nat, %Nat* %z4, i32 0, i32 1
+  store i64* %15, i64** %16
+  %17 = getelementptr %MySum, %MySum* %x1, i32 0, i32 0
+  %18 = load i8, i8* %17
+  %19 = getelementptr %MySum, %MySum* %x1, i32 0, i32 1
+  %20 = load i64*, i64** %19
+  switch i8 %18, label %case.0.ret [
     i8 0, label %case.0.ret
     i8 1, label %case.1.ret
     i8 2, label %case.2.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u2 = load i64, i64* %15
-  %16 = alloca i64
-  store i64 0, i64* %16
-  %17 = load i64, i64* %16
+  %_u2 = load i64, i64* %20
+  %21 = alloca i64
+  store i64 0, i64* %21
+  %22 = load i64, i64* %21
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %18 = bitcast i64* %15 to double*
-  %_u3 = load double, double* %18
-  %19 = call i64 @f(double %_u3, i8 %y)
+  %23 = bitcast i64* %20 to double*
+  %_u3 = load double, double* %23
+  %24 = call i64 @f(double %_u3, i8 %y)
   br label %case.end.ret
 
 case.2.ret:                                       ; preds = %entry
-  %20 = call i64 @countNat(%Nat* %z)
+  %25 = call i64 @countNat(%Nat* %z4)
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %17, %case.0.ret ], [ %19, %case.1.ret ], [ %20, %case.2.ret ]
+  %ret = phi i64 [ %22, %case.0.ret ], [ %24, %case.1.ret ], [ %25, %case.2.ret ]
   ret i64 %ret
 }
 

--- a/integration-tests/pass/fib/fib.ll
+++ b/integration-tests/pass/fib/fib.ll
@@ -1,6 +1,8 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
   %ret = call i64 @fib(i64 10)

--- a/integration-tests/pass/funcargs/funcargs.ll
+++ b/integration-tests/pass/funcargs/funcargs.ll
@@ -1,6 +1,8 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
   %ret = call i64 @apply(i64 (i64, i64)* @myAdd)

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
@@ -1,12 +1,15 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
-  %0 = alloca i64
-  store i64 1, i64* %0
-  %1 = call i64* @idFancy(i64* (i64*)* @id, i64* %0)
-  %ret = load i64, i64* %1
+  %0 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %1 = bitcast i8* %0 to i64*
+  store i64 1, i64* %1
+  %2 = call i64* @idFancy(i64* (i64*)* @id, i64* %1)
+  %ret = load i64, i64* %2
   ret i64 %ret
 }
 

--- a/integration-tests/pass/let/let.ll
+++ b/integration-tests/pass/let/let.ll
@@ -1,6 +1,8 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 declare i64 @abs(i64)
 
 define i64 @main() {

--- a/integration-tests/pass/poly-data/poly-data.ll
+++ b/integration-tests/pass/poly-data/poly-data.ll
@@ -3,6 +3,8 @@ source_filename = "<string>"
 
 %Either = type { i1, i64* }
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
   %res1 = call %Either* @f()
@@ -81,63 +83,76 @@ case.end.ret:                                     ; preds = %case.end.6, %case.0
 
 define private %Either* @f() {
 entry:
-  %res3 = alloca %Either
-  %0 = getelementptr %Either, %Either* %res3, i32 0, i32 0
-  store i1 false, i1* %0
-  %1 = alloca i64
-  store i64 42, i64* %1
-  %2 = getelementptr %Either, %Either* %res3, i32 0, i32 1
-  store i64* %1, i64** %2
-  %3 = getelementptr %Either, %Either* %res3, i32 0, i32 0
-  %4 = load i1, i1* %3
-  %5 = getelementptr %Either, %Either* %res3, i32 0, i32 1
-  %6 = load i64*, i64** %5
-  switch i1 %4, label %case.0.ret [
+  %0 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %res3 = bitcast i8* %0 to %Either*
+  %res31 = alloca %Either
+  %1 = getelementptr %Either, %Either* %res31, i32 0, i32 0
+  store i1 false, i1* %1
+  %2 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %3 = bitcast i8* %2 to i64*
+  store i64 42, i64* %3
+  %4 = getelementptr %Either, %Either* %res31, i32 0, i32 1
+  store i64* %3, i64** %4
+  %5 = getelementptr %Either, %Either* %res31, i32 0, i32 0
+  %6 = load i1, i1* %5
+  %7 = getelementptr %Either, %Either* %res31, i32 0, i32 1
+  %8 = load i64*, i64** %7
+  switch i1 %6, label %case.0.ret [
     i1 false, label %case.0.ret
     i1 true, label %case.1.ret
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u10 = load i64, i64* %6
-  %7 = alloca %Either
-  %8 = getelementptr %Either, %Either* %7, i32 0, i32 0
-  store i1 false, i1* %8
-  %9 = alloca i64
-  store i64 %_u10, i64* %9
-  %10 = getelementptr %Either, %Either* %7, i32 0, i32 1
-  store i64* %9, i64** %10
+  %_u10 = load i64, i64* %8
+  %9 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %10 = bitcast i8* %9 to %Either*
+  %11 = alloca %Either
+  %12 = getelementptr %Either, %Either* %11, i32 0, i32 0
+  store i1 false, i1* %12
+  %13 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %14 = bitcast i8* %13 to i64*
+  store i64 %_u10, i64* %14
+  %15 = getelementptr %Either, %Either* %11, i32 0, i32 1
+  store i64* %14, i64** %15
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %11 = alloca i64*
-  store i64* %6, i64** %11
-  %_u11 = load i64*, i64** %11
-  %12 = alloca %Either
-  %13 = getelementptr %Either, %Either* %12, i32 0, i32 0
-  store i1 true, i1* %13
-  %14 = getelementptr %Either, %Either* %12, i32 0, i32 1
-  store i64* %_u11, i64** %14
+  %16 = alloca i64*
+  store i64* %8, i64** %16
+  %_u11 = load i64*, i64** %16
+  %17 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %18 = bitcast i8* %17 to %Either*
+  %19 = alloca %Either
+  %20 = getelementptr %Either, %Either* %19, i32 0, i32 0
+  store i1 true, i1* %20
+  %21 = getelementptr %Either, %Either* %19, i32 0, i32 1
+  store i64* %_u11, i64** %21
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi %Either* [ %7, %case.0.ret ], [ %12, %case.1.ret ]
+  %ret = phi %Either* [ %11, %case.0.ret ], [ %19, %case.1.ret ]
   ret %Either* %ret
 }
 
 define private %Either* @h() {
 entry:
-  %res4 = alloca %Either
-  %0 = getelementptr %Either, %Either* %res4, i32 0, i32 0
-  store i1 true, i1* %0
-  %1 = alloca i64
-  store i64 1, i64* %1
-  %2 = getelementptr %Either, %Either* %res4, i32 0, i32 1
-  store i64* %1, i64** %2
-  %ret = alloca %Either
-  %3 = getelementptr %Either, %Either* %ret, i32 0, i32 0
-  store i1 true, i1* %3
-  %4 = bitcast %Either* %res4 to i64*
-  %5 = getelementptr %Either, %Either* %ret, i32 0, i32 1
-  store i64* %4, i64** %5
-  ret %Either* %ret
+  %0 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %res4 = bitcast i8* %0 to %Either*
+  %res41 = alloca %Either
+  %1 = getelementptr %Either, %Either* %res41, i32 0, i32 0
+  store i1 true, i1* %1
+  %2 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %3 = bitcast i8* %2 to i64*
+  store i64 1, i64* %3
+  %4 = getelementptr %Either, %Either* %res41, i32 0, i32 1
+  store i64* %3, i64** %4
+  %5 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %ret = bitcast i8* %5 to %Either*
+  %ret2 = alloca %Either
+  %6 = getelementptr %Either, %Either* %ret2, i32 0, i32 0
+  store i1 true, i1* %6
+  %7 = bitcast %Either* %res41 to i64*
+  %8 = getelementptr %Either, %Either* %ret2, i32 0, i32 1
+  store i64* %7, i64** %8
+  ret %Either* %ret2
 }

--- a/integration-tests/pass/poly/poly.ll
+++ b/integration-tests/pass/poly/poly.ll
@@ -1,23 +1,28 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
-  %0 = alloca double
-  store double 3.100000e+00, double* %0
-  %1 = bitcast double* %0 to i64*
-  %2 = call i64* @id(i64* %1)
-  %3 = bitcast i64* %2 to double*
-  %res1 = load double, double* %3
-  %4 = alloca double
-  store double %res1, double* %4
-  %5 = bitcast double* %4 to i64*
-  %6 = alloca double
-  store double 5.100000e+00, double* %6
+  %0 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %1 = bitcast i8* %0 to double*
+  store double 3.100000e+00, double* %1
+  %2 = bitcast double* %1 to i64*
+  %3 = call i64* @id(i64* %2)
+  %4 = bitcast i64* %3 to double*
+  %res1 = load double, double* %4
+  %5 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %6 = bitcast i8* %5 to double*
+  store double %res1, double* %6
   %7 = bitcast double* %6 to i64*
-  %8 = call i64* @const(i64* %5, i64* %7)
-  %9 = bitcast i64* %8 to double*
-  %res2 = load double, double* %9
+  %8 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %9 = bitcast i8* %8 to double*
+  store double 5.100000e+00, double* %9
+  %10 = bitcast double* %9 to i64*
+  %11 = call i64* @const(i64* %7, i64* %10)
+  %12 = bitcast i64* %11 to double*
+  %res2 = load double, double* %12
   %ret = fptoui double %res2 to i64
   ret i64 %ret
 }

--- a/integration-tests/pass/primops/primops.ll
+++ b/integration-tests/pass/primops/primops.ll
@@ -1,6 +1,8 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
   %0 = alloca i64

--- a/integration-tests/pass/records/records.ll
+++ b/integration-tests/pass/records/records.ll
@@ -3,13 +3,16 @@ source_filename = "<string>"
 
 %List = type { i1, i64* }
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
-  %res1 = alloca { i64, i64 }
-  %0 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 0
-  store i64 1, i64* %0
-  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 1
-  store i64 2, i64* %1
+  %0 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %res1 = bitcast i8* %0 to { i64, i64 }*
+  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 0
+  store i64 1, i64* %1
+  %2 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 1
+  store i64 2, i64* %2
   %ret = call i64 @addXY({ i64, i64 }* %res1)
   ret i64 %ret
 }
@@ -26,42 +29,51 @@ entry:
 
 define private { i64*, i64 }* @g(i64* %x) {
 entry:
-  %ret = alloca { i64*, i64 }
-  %0 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 0
-  store i64* %x, i64** %0
-  %1 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 1
-  store i64 1, i64* %1
+  %0 = call i8* @malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
+  %ret = bitcast i8* %0 to { i64*, i64 }*
+  %1 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 0
+  store i64* %x, i64** %1
+  %2 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 1
+  store i64 1, i64* %2
   ret { i64*, i64 }* %ret
 }
 
 define private %List* @h(i64* %x) {
 entry:
-  %cdr4 = alloca %List
-  %0 = getelementptr %List, %List* %cdr4, i32 0, i32 0
-  store i1 false, i1* %0
-  %cdr5 = alloca { i64*, %List* }
-  %1 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 0
-  store i64* %x, i64** %1
-  %2 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 1
-  store %List* %cdr4, %List** %2
-  %cdr6 = alloca %List
-  %3 = getelementptr %List, %List* %cdr6, i32 0, i32 0
-  store i1 true, i1* %3
-  %4 = bitcast { i64*, %List* }* %cdr5 to i64*
-  %5 = getelementptr %List, %List* %cdr6, i32 0, i32 1
-  store i64* %4, i64** %5
-  %res7 = alloca { i64*, %List* }
-  %6 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 0
-  store i64* %x, i64** %6
-  %7 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 1
-  store %List* %cdr6, %List** %7
-  %ret = alloca %List
-  %8 = getelementptr %List, %List* %ret, i32 0, i32 0
-  store i1 true, i1* %8
-  %9 = bitcast { i64*, %List* }* %res7 to i64*
-  %10 = getelementptr %List, %List* %ret, i32 0, i32 1
-  store i64* %9, i64** %10
-  ret %List* %ret
+  %0 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %cdr4 = bitcast i8* %0 to %List*
+  %cdr41 = alloca %List
+  %1 = getelementptr %List, %List* %cdr41, i32 0, i32 0
+  store i1 false, i1* %1
+  %2 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %cdr5 = bitcast i8* %2 to { i64*, %List* }*
+  %3 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 0
+  store i64* %x, i64** %3
+  %4 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 1
+  store %List* %cdr41, %List** %4
+  %5 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %cdr6 = bitcast i8* %5 to %List*
+  %cdr62 = alloca %List
+  %6 = getelementptr %List, %List* %cdr62, i32 0, i32 0
+  store i1 true, i1* %6
+  %7 = bitcast { i64*, %List* }* %cdr5 to i64*
+  %8 = getelementptr %List, %List* %cdr62, i32 0, i32 1
+  store i64* %7, i64** %8
+  %9 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %res7 = bitcast i8* %9 to { i64*, %List* }*
+  %10 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 0
+  store i64* %x, i64** %10
+  %11 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 1
+  store %List* %cdr62, %List** %11
+  %12 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %ret = bitcast i8* %12 to %List*
+  %ret3 = alloca %List
+  %13 = getelementptr %List, %List* %ret3, i32 0, i32 0
+  store i1 true, i1* %13
+  %14 = bitcast { i64*, %List* }* %res7 to i64*
+  %15 = getelementptr %List, %List* %ret3, i32 0, i32 1
+  store i64* %14, i64** %15
+  ret %List* %ret3
 }
 
 define private { i64, i1 }* @a() {
@@ -72,23 +84,25 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %0 = alloca { i64, i1 }
-  %1 = getelementptr { i64, i1 }, { i64, i1 }* %0, i32 0, i32 0
-  store i64 1, i64* %1
-  %2 = getelementptr { i64, i1 }, { i64, i1 }* %0, i32 0, i32 1
-  store i1 true, i1* %2
+  %0 = call i8* @malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
+  %1 = bitcast i8* %0 to { i64, i1 }*
+  %2 = getelementptr { i64, i1 }, { i64, i1 }* %1, i32 0, i32 0
+  store i64 1, i64* %2
+  %3 = getelementptr { i64, i1 }, { i64, i1 }* %1, i32 0, i32 1
+  store i1 true, i1* %3
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %3 = alloca { i64, i1 }
-  %4 = getelementptr { i64, i1 }, { i64, i1 }* %3, i32 0, i32 0
-  store i64 2, i64* %4
-  %5 = getelementptr { i64, i1 }, { i64, i1 }* %3, i32 0, i32 1
-  store i1 false, i1* %5
+  %4 = call i8* @malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
+  %5 = bitcast i8* %4 to { i64, i1 }*
+  %6 = getelementptr { i64, i1 }, { i64, i1 }* %5, i32 0, i32 0
+  store i64 2, i64* %6
+  %7 = getelementptr { i64, i1 }, { i64, i1 }* %5, i32 0, i32 1
+  store i1 false, i1* %7
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi { i64, i1 }* [ %0, %case.0.ret ], [ %3, %case.1.ret ]
+  %ret = phi { i64, i1 }* [ %1, %case.0.ret ], [ %5, %case.1.ret ]
   ret { i64, i1 }* %ret
 }
 
@@ -100,12 +114,13 @@ entry:
   %y9 = load i64*, i64** %1
   %2 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 2
   %z10 = load i64*, i64** %2
-  %ret = alloca { i64*, i64*, i64* }
-  %3 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 0
-  store i64* %x8, i64** %3
-  %4 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 1
-  store i64* %y9, i64** %4
-  %5 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 2
-  store i64* %z10, i64** %5
+  %3 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %ret = bitcast i8* %3 to { i64*, i64*, i64* }*
+  %4 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 0
+  store i64* %x8, i64** %4
+  %5 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 1
+  store i64* %y9, i64** %5
+  %6 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 2
+  store i64* %z10, i64** %6
   ret { i64*, i64*, i64* }* %ret
 }

--- a/integration-tests/pass/semicolons/semicolons.ll
+++ b/integration-tests/pass/semicolons/semicolons.ll
@@ -1,6 +1,8 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
+declare i8* @malloc(i64)
+
 define i64 @main() {
 entry:
   %0 = alloca i64

--- a/integration-tests/pass/text/text.ll
+++ b/integration-tests/pass/text/text.ll
@@ -3,6 +3,8 @@ source_filename = "<string>"
 
 @"$str.2" = private global [21 x i8] c"Hello\0Awith\09\22escapes\22\00"
 
+declare i8* @malloc(i64)
+
 declare i64 @puts(i8*)
 
 define i64 @main() {

--- a/library/Amy/Codegen/Malloc.hs
+++ b/library/Amy/Codegen/Malloc.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Amy.Codegen.Malloc
+  ( mallocDefinition
+  , callMalloc
+  ) where
+
+import LLVM.AST
+import LLVM.AST.AddrSpace
+import qualified LLVM.AST.CallingConvention as CC
+import qualified LLVM.AST.Constant as C
+import LLVM.AST.Global as LLVM
+
+import Amy.Codegen.Monad
+
+mallocDefinition :: Definition
+mallocDefinition =
+  GlobalDefinition
+  functionDefaults
+  { name = "malloc"
+  , parameters = ([Parameter mallocArgType (UnName 0) []], False)
+  , LLVM.returnType = mallocReturnType
+  }
+
+-- N.B. This only applies to 64 bit platforms. We probably need to get the
+-- exact malloc type for the target machine.
+mallocArgType :: Type
+mallocArgType = IntegerType 64
+
+mallocReturnType :: Type
+mallocReturnType = PointerType (IntegerType 8) (AddrSpace 0)
+
+mallocFunctionType :: Type
+mallocFunctionType =
+  FunctionType
+  { resultType = mallocReturnType
+  , argumentTypes = [mallocArgType]
+  , isVarArg = False
+  }
+
+callMalloc :: Name -> Type -> BlockGen Operand
+callMalloc ptrName ty = do
+  -- Compute size of type
+  size <- sizeOfType ty
+
+  -- Call malloc
+  mallocName <- freshUnName
+  let
+    funcOp = ConstantOperand $ C.GlobalReference (PointerType mallocFunctionType (AddrSpace 0)) "malloc"
+    mallocOp = LocalReference mallocReturnType mallocName
+  addInstruction $ mallocName := Call Nothing CC.C [] (Right funcOp) [(size, [])] [] []
+
+  -- Bitcast pointer to what caller intended
+  let
+    ptrTy = PointerType ty (AddrSpace 0)
+    ptrOp = LocalReference ptrTy ptrName
+  addInstruction $ ptrName := BitCast mallocOp ptrTy []
+  pure ptrOp
+
+-- | Uses getelemtnptr to compute the size of an LLVM type. See
+-- https://stackoverflow.com/a/30830445/1333514
+sizeOfType :: Type -> BlockGen Operand
+sizeOfType ty = do
+  -- Compute size of type using getelementptr
+  ptrName <- freshUnName
+  let
+    ptrTy = PointerType ty (AddrSpace 0)
+    ptrOp = LocalReference ptrTy ptrName
+    nullOp = ConstantOperand $ C.Null ptrTy
+  addInstruction $ ptrName := GetElementPtr False nullOp [ConstantOperand (C.Int 32 1)] []
+
+  -- Convert pointer size to an int
+  sizeName <- freshUnName
+  let
+    sizeTy = mallocArgType
+    sizeOp = LocalReference sizeTy sizeName
+  addInstruction $ sizeName := PtrToInt ptrOp sizeTy []
+  pure sizeOp

--- a/library/Amy/Codegen/TypeConversion.hs
+++ b/library/Amy/Codegen/TypeConversion.hs
@@ -14,6 +14,7 @@ import LLVM.AST.AddrSpace
 import qualified LLVM.AST.Constant as C
 import LLVM.AST.Float as F
 
+import Amy.Codegen.Malloc
 import Amy.Codegen.Monad
 
 maybeConvertPointer :: Maybe Name -> Operand -> Type -> BlockGen Operand
@@ -34,8 +35,7 @@ allocOp op = do
   storeName <- freshUnName
   let
     opTy = operandType op
-    storeOp = LocalReference (PointerType opTy (AddrSpace 0)) storeName
-  addInstruction $ storeName := Alloca opTy Nothing 0 []
+  storeOp <- callMalloc storeName opTy
   addInstruction $ Do $ Store False storeOp op Nothing 0 []
   pure storeOp
 


### PR DESCRIPTION
I've known about this problem for some time, but I waited to fix it until my recent garbage collection efforts.

I was using `alloca` on escaping pointers. By that I mean I was allocating memory on the stack for some data structure, and then returning the pointer from the current function. That is no bueno of course because this is stack-allocated memory that will get reclaimed once the function exits. I think the only reason all my test code worked was because I never called a function _after_ one that did `alloca` :smile: 