### PR TITLE
Use the Boehm garbage collector

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -30,6 +30,13 @@ RUN \
   ln -s /usr/bin/clang-6.0 /usr/bin/clang && \
   rm -rf /var/lib/apt/lists/*
 
+# Install Boehm garbage collector
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    libgc-dev && \
+  rm -rf /var/lib/apt/lists/*
+
 # Install stack
 ENV STACK_VERSION 1.7.1
 RUN \

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -75,7 +75,7 @@ process filePath DumpFlags{..} input = do
 
     -- Compile with clang
     let exeFile = takeDirectory filePath </> "a.out"
-    lift $ callProcess "clang" [llvmFile, "-o", exeFile]
+    lift $ callProcess "clang" [llvmFile, "-lgc", "-o", exeFile]
 
   either (die . intercalate "\n") pure eResult
 

--- a/integration-tests/pass/data/data.ll
+++ b/integration-tests/pass/data/data.ll
@@ -4,16 +4,16 @@ source_filename = "<string>"
 %MySum = type { i8, i64* }
 %Nat = type { i1, i64* }
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (%MySum* getelementptr (%MySum, %MySum* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%MySum* getelementptr (%MySum, %MySum* null, i32 1) to i64))
   %x = bitcast i8* %0 to %MySum*
   %x1 = alloca %MySum
   %1 = getelementptr %MySum, %MySum* %x1, i32 0, i32 0
   store i8 1, i8* %1
-  %2 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %2 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
   %3 = bitcast i8* %2 to double*
   store double 0x401F333333333333, double* %3
   %4 = bitcast double* %3 to i64*
@@ -22,12 +22,12 @@ entry:
   %6 = alloca i8
   store i8 1, i8* %6
   %y = load i8, i8* %6
-  %7 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %7 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
   %z1 = bitcast i8* %7 to %Nat*
   %z12 = alloca %Nat
   %8 = getelementptr %Nat, %Nat* %z12, i32 0, i32 0
   store i1 false, i1* %8
-  %9 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %9 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
   %z2 = bitcast i8* %9 to %Nat*
   %z23 = alloca %Nat
   %10 = getelementptr %Nat, %Nat* %z23, i32 0, i32 0
@@ -35,7 +35,7 @@ entry:
   %11 = bitcast %Nat* %z12 to i64*
   %12 = getelementptr %Nat, %Nat* %z23, i32 0, i32 1
   store i64* %11, i64** %12
-  %13 = call i8* @malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %13 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
   %z = bitcast i8* %13 to %Nat*
   %z4 = alloca %Nat
   %14 = getelementptr %Nat, %Nat* %z4, i32 0, i32 0

--- a/integration-tests/pass/fib/fib.ll
+++ b/integration-tests/pass/fib/fib.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:

--- a/integration-tests/pass/funcargs/funcargs.ll
+++ b/integration-tests/pass/funcargs/funcargs.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
@@ -1,11 +1,11 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
   %1 = bitcast i8* %0 to i64*
   store i64 1, i64* %1
   %2 = call i64* @idFancy(i64* (i64*)* @id, i64* %1)

--- a/integration-tests/pass/let/let.ll
+++ b/integration-tests/pass/let/let.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 declare i64 @abs(i64)
 

--- a/integration-tests/pass/poly-data/poly-data.ll
+++ b/integration-tests/pass/poly-data/poly-data.ll
@@ -3,7 +3,7 @@ source_filename = "<string>"
 
 %Either = type { i1, i64* }
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:
@@ -83,12 +83,12 @@ case.end.ret:                                     ; preds = %case.end.6, %case.0
 
 define private %Either* @f() {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %res3 = bitcast i8* %0 to %Either*
   %res31 = alloca %Either
   %1 = getelementptr %Either, %Either* %res31, i32 0, i32 0
   store i1 false, i1* %1
-  %2 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
   %3 = bitcast i8* %2 to i64*
   store i64 42, i64* %3
   %4 = getelementptr %Either, %Either* %res31, i32 0, i32 1
@@ -104,12 +104,12 @@ entry:
 
 case.0.ret:                                       ; preds = %entry, %entry
   %_u10 = load i64, i64* %8
-  %9 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %9 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %10 = bitcast i8* %9 to %Either*
   %11 = alloca %Either
   %12 = getelementptr %Either, %Either* %11, i32 0, i32 0
   store i1 false, i1* %12
-  %13 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %13 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
   %14 = bitcast i8* %13 to i64*
   store i64 %_u10, i64* %14
   %15 = getelementptr %Either, %Either* %11, i32 0, i32 1
@@ -120,7 +120,7 @@ case.1.ret:                                       ; preds = %entry
   %16 = alloca i64*
   store i64* %8, i64** %16
   %_u11 = load i64*, i64** %16
-  %17 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %17 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %18 = bitcast i8* %17 to %Either*
   %19 = alloca %Either
   %20 = getelementptr %Either, %Either* %19, i32 0, i32 0
@@ -136,17 +136,17 @@ case.end.ret:                                     ; preds = %case.1.ret, %case.0
 
 define private %Either* @h() {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %res4 = bitcast i8* %0 to %Either*
   %res41 = alloca %Either
   %1 = getelementptr %Either, %Either* %res41, i32 0, i32 0
   store i1 true, i1* %1
-  %2 = call i8* @malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
   %3 = bitcast i8* %2 to i64*
   store i64 1, i64* %3
   %4 = getelementptr %Either, %Either* %res41, i32 0, i32 1
   store i64* %3, i64** %4
-  %5 = call i8* @malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %5 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %ret = bitcast i8* %5 to %Either*
   %ret2 = alloca %Either
   %6 = getelementptr %Either, %Either* %ret2, i32 0, i32 0

--- a/integration-tests/pass/poly/poly.ll
+++ b/integration-tests/pass/poly/poly.ll
@@ -1,22 +1,22 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
   %1 = bitcast i8* %0 to double*
   store double 3.100000e+00, double* %1
   %2 = bitcast double* %1 to i64*
   %3 = call i64* @id(i64* %2)
   %4 = bitcast i64* %3 to double*
   %res1 = load double, double* %4
-  %5 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %5 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
   %6 = bitcast i8* %5 to double*
   store double %res1, double* %6
   %7 = bitcast double* %6 to i64*
-  %8 = call i8* @malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %8 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
   %9 = bitcast i8* %8 to double*
   store double 5.100000e+00, double* %9
   %10 = bitcast double* %9 to i64*

--- a/integration-tests/pass/primops/primops.ll
+++ b/integration-tests/pass/primops/primops.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:

--- a/integration-tests/pass/records/records.ll
+++ b/integration-tests/pass/records/records.ll
@@ -3,11 +3,11 @@ source_filename = "<string>"
 
 %List = type { i1, i64* }
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:
-  %0 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %0 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
   %res1 = bitcast i8* %0 to { i64, i64 }*
   %1 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 0
   store i64 1, i64* %1
@@ -29,7 +29,7 @@ entry:
 
 define private { i64*, i64 }* @g(i64* %x) {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
   %ret = bitcast i8* %0 to { i64*, i64 }*
   %1 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 0
   store i64* %x, i64** %1
@@ -40,18 +40,18 @@ entry:
 
 define private %List* @h(i64* %x) {
 entry:
-  %0 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
   %cdr4 = bitcast i8* %0 to %List*
   %cdr41 = alloca %List
   %1 = getelementptr %List, %List* %cdr41, i32 0, i32 0
   store i1 false, i1* %1
-  %2 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %2 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %cdr5 = bitcast i8* %2 to { i64*, %List* }*
   %3 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 0
   store i64* %x, i64** %3
   %4 = getelementptr { i64*, %List* }, { i64*, %List* }* %cdr5, i32 0, i32 1
   store %List* %cdr41, %List** %4
-  %5 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %5 = call i8* @GC_malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
   %cdr6 = bitcast i8* %5 to %List*
   %cdr62 = alloca %List
   %6 = getelementptr %List, %List* %cdr62, i32 0, i32 0
@@ -59,13 +59,13 @@ entry:
   %7 = bitcast { i64*, %List* }* %cdr5 to i64*
   %8 = getelementptr %List, %List* %cdr62, i32 0, i32 1
   store i64* %7, i64** %8
-  %9 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %9 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %res7 = bitcast i8* %9 to { i64*, %List* }*
   %10 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 0
   store i64* %x, i64** %10
   %11 = getelementptr { i64*, %List* }, { i64*, %List* }* %res7, i32 0, i32 1
   store %List* %cdr62, %List** %11
-  %12 = call i8* @malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
+  %12 = call i8* @GC_malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
   %ret = bitcast i8* %12 to %List*
   %ret3 = alloca %List
   %13 = getelementptr %List, %List* %ret3, i32 0, i32 0
@@ -84,7 +84,7 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %0 = call i8* @malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
+  %0 = call i8* @GC_malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
   %1 = bitcast i8* %0 to { i64, i1 }*
   %2 = getelementptr { i64, i1 }, { i64, i1 }* %1, i32 0, i32 0
   store i64 1, i64* %2
@@ -93,7 +93,7 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %4 = call i8* @malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
+  %4 = call i8* @GC_malloc(i64 ptrtoint ({ i64, i1 }* getelementptr ({ i64, i1 }, { i64, i1 }* null, i32 1) to i64))
   %5 = bitcast i8* %4 to { i64, i1 }*
   %6 = getelementptr { i64, i1 }, { i64, i1 }* %5, i32 0, i32 0
   store i64 2, i64* %6
@@ -114,7 +114,7 @@ entry:
   %y9 = load i64*, i64** %1
   %2 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 2
   %z10 = load i64*, i64** %2
-  %3 = call i8* @malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %3 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
   %ret = bitcast i8* %3 to { i64*, i64*, i64* }*
   %4 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 0
   store i64* %x8, i64** %4

--- a/integration-tests/pass/semicolons/semicolons.ll
+++ b/integration-tests/pass/semicolons/semicolons.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 define i64 @main() {
 entry:

--- a/integration-tests/pass/text/text.ll
+++ b/integration-tests/pass/text/text.ll
@@ -3,7 +3,7 @@ source_filename = "<string>"
 
 @"$str.2" = private global [21 x i8] c"Hello\0Awith\09\22escapes\22\00"
 
-declare i8* @malloc(i64)
+declare i8* @GC_malloc(i64)
 
 declare i64 @puts(i8*)
 

--- a/library/Amy/Codegen/Malloc.hs
+++ b/library/Amy/Codegen/Malloc.hs
@@ -17,7 +17,7 @@ mallocDefinition :: Definition
 mallocDefinition =
   GlobalDefinition
   functionDefaults
-  { name = "malloc"
+  { name = "GC_malloc"
   , parameters = ([Parameter mallocArgType (UnName 0) []], False)
   , LLVM.returnType = mallocReturnType
   }
@@ -46,7 +46,7 @@ callMalloc ptrName ty = do
   -- Call malloc
   mallocName <- freshUnName
   let
-    funcOp = ConstantOperand $ C.GlobalReference (PointerType mallocFunctionType (AddrSpace 0)) "malloc"
+    funcOp = ConstantOperand $ C.GlobalReference (PointerType mallocFunctionType (AddrSpace 0)) "GC_malloc"
     mallocOp = LocalReference mallocReturnType mallocName
   addInstruction $ mallocName := Call Nothing CC.C [] (Right funcOp) [(size, [])] [] []
 


### PR DESCRIPTION
Just replace `malloc` with `GH_malloc` and use `-lgc` with `clang`. Could it be that easy? Apparently!

I've done a ton of investigation into garbage collection on top of LLVM recently. All roads point to a lot of work against poorly documented APIs. Using the conservative Boehm garbage collector just seems like a simple, no brainer first step to get _some_ GC before diving into the more advanced GCs out there.

I also love having GC as a library. Wiring in deep GC integration into the compiler is quite daunting, and makes switching implementations a lot harder.