### PR TITLE
Compute binding groups using dependency order and type check in order

### DIFF
--- a/integration-tests/pass/data/data.ll
+++ b/integration-tests/pass/data/data.ll
@@ -1,79 +1,10 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-%MySum = type { i8, i64* }
 %Nat = type { i1, i64* }
+%MySum = type { i8, i64* }
 
 declare i8* @GC_malloc(i64)
-
-define i64 @main() {
-entry:
-  %0 = call i8* @GC_malloc(i64 ptrtoint (%MySum* getelementptr (%MySum, %MySum* null, i32 1) to i64))
-  %x = bitcast i8* %0 to %MySum*
-  %x1 = alloca %MySum
-  %1 = getelementptr %MySum, %MySum* %x1, i32 0, i32 0
-  store i8 1, i8* %1
-  %2 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
-  %3 = bitcast i8* %2 to double*
-  store double 0x401F333333333333, double* %3
-  %4 = bitcast double* %3 to i64*
-  %5 = getelementptr %MySum, %MySum* %x1, i32 0, i32 1
-  store i64* %4, i64** %5
-  %6 = alloca i8
-  store i8 1, i8* %6
-  %y = load i8, i8* %6
-  %7 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
-  %z1 = bitcast i8* %7 to %Nat*
-  %z12 = alloca %Nat
-  %8 = getelementptr %Nat, %Nat* %z12, i32 0, i32 0
-  store i1 false, i1* %8
-  %9 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
-  %z2 = bitcast i8* %9 to %Nat*
-  %z23 = alloca %Nat
-  %10 = getelementptr %Nat, %Nat* %z23, i32 0, i32 0
-  store i1 true, i1* %10
-  %11 = bitcast %Nat* %z12 to i64*
-  %12 = getelementptr %Nat, %Nat* %z23, i32 0, i32 1
-  store i64* %11, i64** %12
-  %13 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
-  %z = bitcast i8* %13 to %Nat*
-  %z4 = alloca %Nat
-  %14 = getelementptr %Nat, %Nat* %z4, i32 0, i32 0
-  store i1 true, i1* %14
-  %15 = bitcast %Nat* %z23 to i64*
-  %16 = getelementptr %Nat, %Nat* %z4, i32 0, i32 1
-  store i64* %15, i64** %16
-  %17 = getelementptr %MySum, %MySum* %x1, i32 0, i32 0
-  %18 = load i8, i8* %17
-  %19 = getelementptr %MySum, %MySum* %x1, i32 0, i32 1
-  %20 = load i64*, i64** %19
-  switch i8 %18, label %case.0.ret [
-    i8 0, label %case.0.ret
-    i8 1, label %case.1.ret
-    i8 2, label %case.2.ret
-  ]
-
-case.0.ret:                                       ; preds = %entry, %entry
-  %_u2 = load i64, i64* %20
-  %21 = alloca i64
-  store i64 0, i64* %21
-  %22 = load i64, i64* %21
-  br label %case.end.ret
-
-case.1.ret:                                       ; preds = %entry
-  %23 = bitcast i64* %20 to double*
-  %_u3 = load double, double* %23
-  %24 = call i64 @f(double %_u3, i8 %y)
-  br label %case.end.ret
-
-case.2.ret:                                       ; preds = %entry
-  %25 = call i64 @countNat(%Nat* %z4)
-  br label %case.end.ret
-
-case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
-  %ret = phi i64 [ %22, %case.0.ret ], [ %24, %case.1.ret ], [ %25, %case.2.ret ]
-  ret i64 %ret
-}
 
 define private i64 @f(double %x, i8 %enum) {
 entry:
@@ -122,12 +53,81 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %_u6 = bitcast i64* %3 to %Nat*
-  %res3 = call i64 @countNat(%Nat* %_u6)
-  %6 = add i64 1, %res3
+  %_u3 = bitcast i64* %3 to %Nat*
+  %res1 = call i64 @countNat(%Nat* %_u3)
+  %6 = add i64 1, %res1
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
   %ret = phi i64 [ %5, %case.0.ret ], [ %6, %case.1.ret ]
+  ret i64 %ret
+}
+
+define i64 @main() {
+entry:
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z2 = bitcast i8* %0 to %Nat*
+  %z21 = alloca %Nat
+  %1 = getelementptr %Nat, %Nat* %z21, i32 0, i32 0
+  store i1 false, i1* %1
+  %2 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z3 = bitcast i8* %2 to %Nat*
+  %z32 = alloca %Nat
+  %3 = getelementptr %Nat, %Nat* %z32, i32 0, i32 0
+  store i1 true, i1* %3
+  %4 = bitcast %Nat* %z21 to i64*
+  %5 = getelementptr %Nat, %Nat* %z32, i32 0, i32 1
+  store i64* %4, i64** %5
+  %6 = call i8* @GC_malloc(i64 ptrtoint (%Nat* getelementptr (%Nat, %Nat* null, i32 1) to i64))
+  %z = bitcast i8* %6 to %Nat*
+  %z4 = alloca %Nat
+  %7 = getelementptr %Nat, %Nat* %z4, i32 0, i32 0
+  store i1 true, i1* %7
+  %8 = bitcast %Nat* %z32 to i64*
+  %9 = getelementptr %Nat, %Nat* %z4, i32 0, i32 1
+  store i64* %8, i64** %9
+  %10 = alloca i8
+  store i8 1, i8* %10
+  %y = load i8, i8* %10
+  %11 = call i8* @GC_malloc(i64 ptrtoint (%MySum* getelementptr (%MySum, %MySum* null, i32 1) to i64))
+  %x = bitcast i8* %11 to %MySum*
+  %x5 = alloca %MySum
+  %12 = getelementptr %MySum, %MySum* %x5, i32 0, i32 0
+  store i8 1, i8* %12
+  %13 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
+  %14 = bitcast i8* %13 to double*
+  store double 0x401F333333333333, double* %14
+  %15 = bitcast double* %14 to i64*
+  %16 = getelementptr %MySum, %MySum* %x5, i32 0, i32 1
+  store i64* %15, i64** %16
+  %17 = getelementptr %MySum, %MySum* %x5, i32 0, i32 0
+  %18 = load i8, i8* %17
+  %19 = getelementptr %MySum, %MySum* %x5, i32 0, i32 1
+  %20 = load i64*, i64** %19
+  switch i8 %18, label %case.0.ret [
+    i8 0, label %case.0.ret
+    i8 1, label %case.1.ret
+    i8 2, label %case.2.ret
+  ]
+
+case.0.ret:                                       ; preds = %entry, %entry
+  %_u5 = load i64, i64* %20
+  %21 = alloca i64
+  store i64 0, i64* %21
+  %22 = load i64, i64* %21
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
+  %23 = bitcast i64* %20 to double*
+  %_u6 = load double, double* %23
+  %24 = call i64 @f(double %_u6, i8 %y)
+  br label %case.end.ret
+
+case.2.ret:                                       ; preds = %entry
+  %25 = call i64 @countNat(%Nat* %z4)
+  br label %case.end.ret
+
+case.end.ret:                                     ; preds = %case.2.ret, %case.1.ret, %case.0.ret
+  %ret = phi i64 [ %22, %case.0.ret ], [ %24, %case.1.ret ], [ %25, %case.2.ret ]
   ret i64 %ret
 }

--- a/integration-tests/pass/fib/fib.ll
+++ b/integration-tests/pass/fib/fib.ll
@@ -3,12 +3,6 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64 @main() {
-entry:
-  %ret = call i64 @fib(i64 10)
-  ret i64 %ret
-}
-
 define private i64 @fib(i64 %x) {
 entry:
   switch i64 %x, label %case.default.ret [
@@ -41,5 +35,11 @@ case.1.ret:                                       ; preds = %entry
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret, %case.default.ret
   %ret = phi i64 [ %1, %case.default.ret ], [ %3, %case.0.ret ], [ %5, %case.1.ret ]
+  ret i64 %ret
+}
+
+define i64 @main() {
+entry:
+  %ret = call i64 @fib(i64 10)
   ret i64 %ret
 }

--- a/integration-tests/pass/funcargs/funcargs.ll
+++ b/integration-tests/pass/funcargs/funcargs.ll
@@ -3,9 +3,9 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64 @main() {
+define private i64 @myAdd(i64 %x, i64 %y) {
 entry:
-  %ret = call i64 @apply(i64 (i64, i64)* @myAdd)
+  %ret = add i64 %x, %y
   ret i64 %ret
 }
 
@@ -15,8 +15,8 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @myAdd(i64 %x, i64 %y) {
+define i64 @main() {
 entry:
-  %ret = add i64 %x, %y
+  %ret = call i64 @apply(i64 (i64, i64)* @myAdd)
   ret i64 %ret
 }

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
@@ -3,14 +3,10 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64 @main() {
+define private i64* @idFancy(i64* (i64*)* %f, i64* %x) {
 entry:
-  %0 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
-  %1 = bitcast i8* %0 to i64*
-  store i64 1, i64* %1
-  %2 = call i64* @idFancy(i64* (i64*)* @id, i64* %1)
-  %ret = load i64, i64* %2
-  ret i64 %ret
+  %ret = call i64* %f(i64* %x)
+  ret i64* %ret
 }
 
 define private i64* @id(i64* %x) {
@@ -21,8 +17,12 @@ entry:
   ret i64* %ret
 }
 
-define private i64* @idFancy(i64* (i64*)* %f, i64* %x) {
+define i64 @main() {
 entry:
-  %ret = call i64* %f(i64* %x)
-  ret i64* %ret
+  %0 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %1 = bitcast i8* %0 to i64*
+  store i64 1, i64* %1
+  %2 = call i64* @idFancy(i64* (i64*)* @id, i64* %1)
+  %ret = load i64, i64* %2
+  ret i64 %ret
 }

--- a/integration-tests/pass/let/let.ll
+++ b/integration-tests/pass/let/let.ll
@@ -5,30 +5,11 @@ declare i8* @GC_malloc(i64)
 
 declare i64 @abs(i64)
 
-define i64 @main() {
+define private i64 @threeHundred() {
 entry:
-  switch i1 true, label %case.0.x [
-    i1 true, label %case.0.x
-    i1 false, label %case.1.x
-  ]
-
-case.0.x:                                         ; preds = %entry, %entry
-  %x1 = call i64 @f(i64 100)
-  %0 = call i64 @abs(i64 %x1)
-  br label %case.end.x
-
-case.1.x:                                         ; preds = %entry
-  %x2 = call i64 @threeHundred()
-  %x3 = call i64 @f(i64 %x2)
-  %1 = call i64 @abs(i64 %x3)
-  br label %case.end.x
-
-case.end.x:                                       ; preds = %case.1.x, %case.0.x
-  %x = phi i64 [ %0, %case.0.x ], [ %1, %case.1.x ]
-  %2 = alloca i64
-  store i64 %x, i64* %2
-  %y = load i64, i64* %2
-  %ret = add i64 %x, %y
+  %0 = alloca i64
+  store i64 300, i64* %0
+  %ret = load i64, i64* %0
   ret i64 %ret
 }
 
@@ -44,9 +25,9 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %res4 = call i64 @threeHundred()
+  %res1 = call i64 @threeHundred()
   %1 = alloca i64
-  store i64 %res4, i64* %1
+  store i64 %res1, i64* %1
   %2 = load i64, i64* %1
   br label %case.end.ret
 
@@ -55,10 +36,29 @@ case.end.ret:                                     ; preds = %case.1.ret, %case.0
   ret i64 %ret
 }
 
-define private i64 @threeHundred() {
+define i64 @main() {
 entry:
-  %0 = alloca i64
-  store i64 300, i64* %0
-  %ret = load i64, i64* %0
+  switch i1 true, label %case.0.x [
+    i1 true, label %case.0.x
+    i1 false, label %case.1.x
+  ]
+
+case.0.x:                                         ; preds = %entry, %entry
+  %x2 = call i64 @f(i64 100)
+  %0 = call i64 @abs(i64 %x2)
+  br label %case.end.x
+
+case.1.x:                                         ; preds = %entry
+  %x3 = call i64 @threeHundred()
+  %x4 = call i64 @f(i64 %x3)
+  %1 = call i64 @abs(i64 %x4)
+  br label %case.end.x
+
+case.end.x:                                       ; preds = %case.1.x, %case.0.x
+  %x = phi i64 [ %0, %case.0.x ], [ %1, %case.1.x ]
+  %2 = alloca i64
+  store i64 %x, i64* %2
+  %y = load i64, i64* %2
+  %ret = add i64 %x, %y
   ret i64 %ret
 }

--- a/integration-tests/pass/poly-data/poly-data.ll
+++ b/integration-tests/pass/poly-data/poly-data.ll
@@ -5,12 +5,88 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
+define private %Either* @h() {
+entry:
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %res1 = bitcast i8* %0 to %Either*
+  %res11 = alloca %Either
+  %1 = getelementptr %Either, %Either* %res11, i32 0, i32 0
+  store i1 true, i1* %1
+  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %3 = bitcast i8* %2 to i64*
+  store i64 1, i64* %3
+  %4 = getelementptr %Either, %Either* %res11, i32 0, i32 1
+  store i64* %3, i64** %4
+  %5 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %ret = bitcast i8* %5 to %Either*
+  %ret2 = alloca %Either
+  %6 = getelementptr %Either, %Either* %ret2, i32 0, i32 0
+  store i1 true, i1* %6
+  %7 = bitcast %Either* %res11 to i64*
+  %8 = getelementptr %Either, %Either* %ret2, i32 0, i32 1
+  store i64* %7, i64** %8
+  ret %Either* %ret2
+}
+
+define private %Either* @f() {
+entry:
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %res2 = bitcast i8* %0 to %Either*
+  %res21 = alloca %Either
+  %1 = getelementptr %Either, %Either* %res21, i32 0, i32 0
+  store i1 false, i1* %1
+  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %3 = bitcast i8* %2 to i64*
+  store i64 42, i64* %3
+  %4 = getelementptr %Either, %Either* %res21, i32 0, i32 1
+  store i64* %3, i64** %4
+  %5 = getelementptr %Either, %Either* %res21, i32 0, i32 0
+  %6 = load i1, i1* %5
+  %7 = getelementptr %Either, %Either* %res21, i32 0, i32 1
+  %8 = load i64*, i64** %7
+  switch i1 %6, label %case.0.ret [
+    i1 false, label %case.0.ret
+    i1 true, label %case.1.ret
+  ]
+
+case.0.ret:                                       ; preds = %entry, %entry
+  %_u2 = load i64, i64* %8
+  %9 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %10 = bitcast i8* %9 to %Either*
+  %11 = alloca %Either
+  %12 = getelementptr %Either, %Either* %11, i32 0, i32 0
+  store i1 false, i1* %12
+  %13 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
+  %14 = bitcast i8* %13 to i64*
+  store i64 %_u2, i64* %14
+  %15 = getelementptr %Either, %Either* %11, i32 0, i32 1
+  store i64* %14, i64** %15
+  br label %case.end.ret
+
+case.1.ret:                                       ; preds = %entry
+  %16 = alloca i64*
+  store i64* %8, i64** %16
+  %_u3 = load i64*, i64** %16
+  %17 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
+  %18 = bitcast i8* %17 to %Either*
+  %19 = alloca %Either
+  %20 = getelementptr %Either, %Either* %19, i32 0, i32 0
+  store i1 true, i1* %20
+  %21 = getelementptr %Either, %Either* %19, i32 0, i32 1
+  store i64* %_u3, i64** %21
+  br label %case.end.ret
+
+case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
+  %ret = phi %Either* [ %11, %case.0.ret ], [ %19, %case.1.ret ]
+  ret %Either* %ret
+}
+
 define i64 @main() {
 entry:
-  %res1 = call %Either* @f()
-  %0 = getelementptr %Either, %Either* %res1, i32 0, i32 0
+  %res3 = call %Either* @f()
+  %0 = getelementptr %Either, %Either* %res3, i32 0, i32 0
   %1 = load i1, i1* %0
-  %2 = getelementptr %Either, %Either* %res1, i32 0, i32 1
+  %2 = getelementptr %Either, %Either* %res3, i32 0, i32 1
   %3 = load i64*, i64** %2
   switch i1 %1, label %case.0.ret [
     i1 false, label %case.0.ret
@@ -18,18 +94,18 @@ entry:
   ]
 
 case.0.ret:                                       ; preds = %entry, %entry
-  %_u7 = load i64, i64* %3
+  %_u10 = load i64, i64* %3
   %4 = alloca i64
-  store i64 %_u7, i64* %4
+  store i64 %_u10, i64* %4
   %5 = load i64, i64* %4
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %_u8 = load i64, i64* %3
-  %res2 = call %Either* @h()
-  %6 = getelementptr %Either, %Either* %res2, i32 0, i32 0
+  %_u11 = load i64, i64* %3
+  %res4 = call %Either* @h()
+  %6 = getelementptr %Either, %Either* %res4, i32 0, i32 0
   %7 = load i1, i1* %6
-  %8 = getelementptr %Either, %Either* %res2, i32 0, i32 1
+  %8 = getelementptr %Either, %Either* %res4, i32 0, i32 1
   %9 = load i64*, i64** %8
   switch i1 %7, label %case.0.6 [
     i1 false, label %case.0.6
@@ -37,17 +113,17 @@ case.1.ret:                                       ; preds = %entry
   ]
 
 case.0.6:                                         ; preds = %case.1.ret, %case.1.ret
-  %_u3 = load i64, i64* %9
+  %_u6 = load i64, i64* %9
   %10 = alloca i64
-  store i64 %_u3, i64* %10
+  store i64 %_u6, i64* %10
   %11 = load i64, i64* %10
   br label %case.end.6
 
 case.1.6:                                         ; preds = %case.1.ret
-  %_u4 = bitcast i64* %9 to %Either*
-  %12 = getelementptr %Either, %Either* %_u4, i32 0, i32 0
+  %_u7 = bitcast i64* %9 to %Either*
+  %12 = getelementptr %Either, %Either* %_u7, i32 0, i32 0
   %13 = load i1, i1* %12
-  %14 = getelementptr %Either, %Either* %_u4, i32 0, i32 1
+  %14 = getelementptr %Either, %Either* %_u7, i32 0, i32 1
   %15 = load i64*, i64** %14
   switch i1 %13, label %case.0.13 [
     i1 false, label %case.0.13
@@ -55,16 +131,16 @@ case.1.6:                                         ; preds = %case.1.ret
   ]
 
 case.0.13:                                        ; preds = %case.1.6, %case.1.6
-  %_u5 = load i64, i64* %15
+  %_u8 = load i64, i64* %15
   %16 = alloca i64
-  store i64 %_u5, i64* %16
+  store i64 %_u8, i64* %16
   %17 = load i64, i64* %16
   br label %case.end.13
 
 case.1.13:                                        ; preds = %case.1.6
-  %_u6 = load i64, i64* %15
+  %_u9 = load i64, i64* %15
   %18 = alloca i64
-  store i64 %_u8, i64* %18
+  store i64 %_u11, i64* %18
   %19 = load i64, i64* %18
   br label %case.end.13
 
@@ -79,80 +155,4 @@ case.end.6:                                       ; preds = %case.end.13, %case.
 case.end.ret:                                     ; preds = %case.end.6, %case.0.ret
   %ret = phi i64 [ %5, %case.0.ret ], [ %21, %case.end.6 ]
   ret i64 %ret
-}
-
-define private %Either* @f() {
-entry:
-  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
-  %res3 = bitcast i8* %0 to %Either*
-  %res31 = alloca %Either
-  %1 = getelementptr %Either, %Either* %res31, i32 0, i32 0
-  store i1 false, i1* %1
-  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
-  %3 = bitcast i8* %2 to i64*
-  store i64 42, i64* %3
-  %4 = getelementptr %Either, %Either* %res31, i32 0, i32 1
-  store i64* %3, i64** %4
-  %5 = getelementptr %Either, %Either* %res31, i32 0, i32 0
-  %6 = load i1, i1* %5
-  %7 = getelementptr %Either, %Either* %res31, i32 0, i32 1
-  %8 = load i64*, i64** %7
-  switch i1 %6, label %case.0.ret [
-    i1 false, label %case.0.ret
-    i1 true, label %case.1.ret
-  ]
-
-case.0.ret:                                       ; preds = %entry, %entry
-  %_u10 = load i64, i64* %8
-  %9 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
-  %10 = bitcast i8* %9 to %Either*
-  %11 = alloca %Either
-  %12 = getelementptr %Either, %Either* %11, i32 0, i32 0
-  store i1 false, i1* %12
-  %13 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
-  %14 = bitcast i8* %13 to i64*
-  store i64 %_u10, i64* %14
-  %15 = getelementptr %Either, %Either* %11, i32 0, i32 1
-  store i64* %14, i64** %15
-  br label %case.end.ret
-
-case.1.ret:                                       ; preds = %entry
-  %16 = alloca i64*
-  store i64* %8, i64** %16
-  %_u11 = load i64*, i64** %16
-  %17 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
-  %18 = bitcast i8* %17 to %Either*
-  %19 = alloca %Either
-  %20 = getelementptr %Either, %Either* %19, i32 0, i32 0
-  store i1 true, i1* %20
-  %21 = getelementptr %Either, %Either* %19, i32 0, i32 1
-  store i64* %_u11, i64** %21
-  br label %case.end.ret
-
-case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
-  %ret = phi %Either* [ %11, %case.0.ret ], [ %19, %case.1.ret ]
-  ret %Either* %ret
-}
-
-define private %Either* @h() {
-entry:
-  %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
-  %res4 = bitcast i8* %0 to %Either*
-  %res41 = alloca %Either
-  %1 = getelementptr %Either, %Either* %res41, i32 0, i32 0
-  store i1 true, i1* %1
-  %2 = call i8* @GC_malloc(i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64))
-  %3 = bitcast i8* %2 to i64*
-  store i64 1, i64* %3
-  %4 = getelementptr %Either, %Either* %res41, i32 0, i32 1
-  store i64* %3, i64** %4
-  %5 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
-  %ret = bitcast i8* %5 to %Either*
-  %ret2 = alloca %Either
-  %6 = getelementptr %Either, %Either* %ret2, i32 0, i32 0
-  store i1 true, i1* %6
-  %7 = bitcast %Either* %res41 to i64*
-  %8 = getelementptr %Either, %Either* %ret2, i32 0, i32 1
-  store i64* %7, i64** %8
-  ret %Either* %ret2
 }

--- a/integration-tests/pass/poly/poly.ll
+++ b/integration-tests/pass/poly/poly.ll
@@ -3,6 +3,22 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
+define private i64* @id(i64* %x) {
+entry:
+  %0 = alloca i64*
+  store i64* %x, i64** %0
+  %ret = load i64*, i64** %0
+  ret i64* %ret
+}
+
+define private i64* @const(i64* %x, i64* %y) {
+entry:
+  %0 = alloca i64*
+  store i64* %x, i64** %0
+  %ret = load i64*, i64** %0
+  ret i64* %ret
+}
+
 define i64 @main() {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64))
@@ -25,20 +41,4 @@ entry:
   %res2 = load double, double* %12
   %ret = fptoui double %res2 to i64
   ret i64 %ret
-}
-
-define private i64* @id(i64* %x) {
-entry:
-  %0 = alloca i64*
-  store i64* %x, i64** %0
-  %ret = load i64*, i64** %0
-  ret i64* %ret
-}
-
-define private i64* @const(i64* %x, i64* %y) {
-entry:
-  %0 = alloca i64*
-  store i64* %x, i64** %0
-  %ret = load i64*, i64** %0
-  ret i64* %ret
 }

--- a/integration-tests/pass/primops/primops.ll
+++ b/integration-tests/pass/primops/primops.ll
@@ -3,22 +3,12 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64 @main() {
-entry:
-  %0 = alloca i64
-  store i64 2, i64* %0
-  %x = load i64, i64* %0
-  %res1 = call i64 @f(i64 %x)
-  %ret = call i64 @f(i64 %res1)
-  ret i64 %ret
-}
-
 define private i64 @f(i64 %x) {
 entry:
   %y = add i64 %x, -1
-  %res3 = sub i64 3, %y
-  %res4 = icmp slt i64 5, %res3
-  switch i1 %res4, label %case.0.ret [
+  %res2 = sub i64 3, %y
+  %res3 = icmp slt i64 5, %res2
+  switch i1 %res3, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
@@ -37,5 +27,15 @@ case.1.ret:                                       ; preds = %entry
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
   %ret = phi i64 [ %1, %case.0.ret ], [ %3, %case.1.ret ]
+  ret i64 %ret
+}
+
+define i64 @main() {
+entry:
+  %0 = alloca i64
+  store i64 2, i64* %0
+  %x = load i64, i64* %0
+  %res4 = call i64 @f(i64 %x)
+  %ret = call i64 @f(i64 %res4)
   ret i64 %ret
 }

--- a/integration-tests/pass/records/records.ll
+++ b/integration-tests/pass/records/records.ll
@@ -5,37 +5,23 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64 @main() {
+define private { i64*, i64*, i64* }* @q({ i64*, i64*, i64* }* %r) {
 entry:
-  %0 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %res1 = bitcast i8* %0 to { i64, i64 }*
-  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 0
-  store i64 1, i64* %1
-  %2 = getelementptr { i64, i64 }, { i64, i64 }* %res1, i32 0, i32 1
-  store i64 2, i64* %2
-  %ret = call i64 @addXY({ i64, i64 }* %res1)
-  ret i64 %ret
-}
-
-define private i64 @addXY({ i64, i64 }* %r) {
-entry:
-  %0 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 0
-  %res2 = load i64, i64* %0
-  %1 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 1
-  %res3 = load i64, i64* %1
-  %ret = add i64 %res2, %res3
-  ret i64 %ret
-}
-
-define private { i64*, i64 }* @g(i64* %x) {
-entry:
-  %0 = call i8* @GC_malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
-  %ret = bitcast i8* %0 to { i64*, i64 }*
-  %1 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 0
-  store i64* %x, i64** %1
-  %2 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 1
-  store i64 1, i64* %2
-  ret { i64*, i64 }* %ret
+  %0 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 0
+  %x1 = load i64*, i64** %0
+  %1 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 1
+  %y2 = load i64*, i64** %1
+  %2 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 2
+  %z3 = load i64*, i64** %2
+  %3 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %ret = bitcast i8* %3 to { i64*, i64*, i64* }*
+  %4 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 0
+  store i64* %x1, i64** %4
+  %5 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 1
+  store i64* %y2, i64** %5
+  %6 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 2
+  store i64* %z3, i64** %6
+  ret { i64*, i64*, i64* }* %ret
 }
 
 define private %List* @h(i64* %x) {
@@ -76,6 +62,39 @@ entry:
   ret %List* %ret3
 }
 
+define private { i64*, i64 }* @g(i64* %x) {
+entry:
+  %0 = call i8* @GC_malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
+  %ret = bitcast i8* %0 to { i64*, i64 }*
+  %1 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 0
+  store i64* %x, i64** %1
+  %2 = getelementptr { i64*, i64 }, { i64*, i64 }* %ret, i32 0, i32 1
+  store i64 1, i64* %2
+  ret { i64*, i64 }* %ret
+}
+
+define private i64 @addXY({ i64, i64 }* %r) {
+entry:
+  %0 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 0
+  %res8 = load i64, i64* %0
+  %1 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 1
+  %res9 = load i64, i64* %1
+  %ret = add i64 %res8, %res9
+  ret i64 %ret
+}
+
+define i64 @main() {
+entry:
+  %0 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %res10 = bitcast i8* %0 to { i64, i64 }*
+  %1 = getelementptr { i64, i64 }, { i64, i64 }* %res10, i32 0, i32 0
+  store i64 1, i64* %1
+  %2 = getelementptr { i64, i64 }, { i64, i64 }* %res10, i32 0, i32 1
+  store i64 2, i64* %2
+  %ret = call i64 @addXY({ i64, i64 }* %res10)
+  ret i64 %ret
+}
+
 define private { i64, i1 }* @a() {
 entry:
   switch i1 true, label %case.0.ret [
@@ -104,23 +123,4 @@ case.1.ret:                                       ; preds = %entry
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret
   %ret = phi { i64, i1 }* [ %1, %case.0.ret ], [ %5, %case.1.ret ]
   ret { i64, i1 }* %ret
-}
-
-define private { i64*, i64*, i64* }* @q({ i64*, i64*, i64* }* %r) {
-entry:
-  %0 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 0
-  %x8 = load i64*, i64** %0
-  %1 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 1
-  %y9 = load i64*, i64** %1
-  %2 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 2
-  %z10 = load i64*, i64** %2
-  %3 = call i8* @GC_malloc(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
-  %ret = bitcast i8* %3 to { i64*, i64*, i64* }*
-  %4 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 0
-  store i64* %x8, i64** %4
-  %5 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 1
-  store i64* %y9, i64** %5
-  %6 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %ret, i32 0, i32 2
-  store i64* %z10, i64** %6
-  ret { i64*, i64*, i64* }* %ret
 }

--- a/integration-tests/pass/semicolons/semicolons.ll
+++ b/integration-tests/pass/semicolons/semicolons.ll
@@ -6,20 +6,20 @@ declare i8* @GC_malloc(i64)
 define i64 @main() {
 entry:
   %0 = alloca i64
-  store i64 1, i64* %0
-  %a = load i64, i64* %0
+  store i64 2, i64* %0
+  %b = load i64, i64* %0
   %1 = alloca i64
-  store i64 2, i64* %1
-  %b = load i64, i64* %1
+  store i64 1, i64* %1
+  %a = load i64, i64* %1
   %2 = alloca i64
-  store i64 3, i64* %2
-  %c = load i64, i64* %2
+  store i64 5, i64* %2
+  %e = load i64, i64* %2
   %3 = alloca i64
   store i64 4, i64* %3
   %d = load i64, i64* %3
   %4 = alloca i64
-  store i64 5, i64* %4
-  %e = load i64, i64* %4
+  store i64 3, i64* %4
+  %c = load i64, i64* %4
   %5 = alloca i64
   store i64 %a, i64* %5
   %ret = load i64, i64* %5

--- a/integration-tests/pass/text/text.ll
+++ b/integration-tests/pass/text/text.ll
@@ -1,26 +1,26 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-@"$str.2" = private global [21 x i8] c"Hello\0Awith\09\22escapes\22\00"
+@"$str.1" = private global [21 x i8] c"Hello\0Awith\09\22escapes\22\00"
 
 declare i8* @GC_malloc(i64)
 
 declare i64 @puts(i8*)
 
+define private i8* @hello() {
+entry:
+  %0 = alloca i8*
+  store i8* getelementptr inbounds ([21 x i8], [21 x i8]* @"$str.1", i32 0, i32 0), i8** %0
+  %ret = load i8*, i8** %0
+  ret i8* %ret
+}
+
 define i64 @main() {
 entry:
-  %x1 = call i8* @hello()
-  %x = call i64 @puts(i8* %x1)
+  %x2 = call i8* @hello()
+  %x = call i64 @puts(i8* %x2)
   %0 = alloca i64
   store i64 0, i64* %0
   %ret = load i64, i64* %0
   ret i64 %ret
-}
-
-define private i8* @hello() {
-entry:
-  %0 = alloca i8*
-  store i8* getelementptr inbounds ([21 x i8], [21 x i8]* @"$str.2", i32 0, i32 0), i8** %0
-  %ret = load i8*, i8** %0
-  ret i8* %ret
 }

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -19,8 +19,10 @@ import Amy.Core.AST as C
 import Amy.Prim
 
 normalizeModule :: C.Module -> ANF.Module
-normalizeModule (C.Module bindings externs typeDeclarations) =
+normalizeModule (C.Module bindingGroups externs typeDeclarations) =
   let
+    bindings = concatMap NE.toList bindingGroups
+
     -- Record top-level names
     topLevelNames =
       (C.bindingName <$> bindings)
@@ -124,7 +126,8 @@ normalizeExpr name expr@(C.ECase (C.Case scrutinee bind matches defaultExpr)) =
     defaultExpr' <- traverse (normalizeExpr name) defaultExpr
     ty <- convertType $ expressionType expr
     pure $ ANF.ECase (ANF.Case scrutineeVal bind' matches' defaultExpr' ty)
-normalizeExpr name (C.ELet (C.Let bindings expr)) = do
+normalizeExpr name (C.ELet (C.Let bindingGroups expr)) = do
+  let bindings = concatMap NE.toList bindingGroups
   bindings' <- traverse normalizeLetBinding bindings
   expr' <- normalizeExpr name expr
   pure $ ANF.ELetVal $ collapseLetVals $ ANF.LetVal bindings' expr'

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -43,7 +43,7 @@ import Amy.Syntax.Located
 
 data Module
   = Module
-  { moduleBindings :: ![Binding]
+  { moduleBindings :: ![NonEmpty Binding]
   , moduleExterns :: ![Extern]
   , moduleTypeDeclarations :: ![TypeDeclaration]
   } deriving (Show, Eq)
@@ -146,7 +146,7 @@ data PatCons
 
 data Let
   = Let
-  { letBindings :: ![Binding]
+  { letBindings :: ![NonEmpty Binding]
   , letExpression :: !Expr
   } deriving (Show, Eq)
 
@@ -199,7 +199,7 @@ substExpr (ECase (Case scrut bind alts default')) var newVar =
     ((\e -> substExpr e var newVar) <$> default')
   )
 substExpr (ELet (Let bindings body)) var newVar =
-  ELet (Let ((\b -> substBinding b var newVar) <$> bindings) (substExpr body var newVar))
+  ELet (Let (fmap (\b -> substBinding b var newVar) <$> bindings) (substExpr body var newVar))
 substExpr (EApp (App f arg ty)) var newVar =
   EApp (App (substExpr f var newVar) (substExpr arg var newVar) ty)
 substExpr (EParens expr) var newVar = EParens (substExpr expr var newVar)

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -37,7 +37,7 @@ prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines
   $ (prettyExtern' <$> externs)
   ++ (prettyTypeDeclaration' <$> typeDeclarations)
-  ++ (prettyBinding' <$> bindings)
+  ++ (prettyBinding' <$> concat (toList <$> bindings))
 
 prettyExtern' :: Extern -> Doc ann
 prettyExtern' (Extern name ty) =
@@ -84,7 +84,7 @@ prettyExpr (ECase (Case scrutinee bind matches mDefault)) =
       Nothing -> []
       Just def -> [("__DEFAULT", prettyExpr def)]
 prettyExpr (ELet (Let bindings body)) =
-  prettyLet (prettyBinding' <$> bindings) (prettyExpr body)
+  prettyLet (prettyBinding' <$> concat (toList <$> bindings)) (prettyExpr body)
 prettyExpr (EApp (App f arg _)) = prettyExpr f <+> prettyExpr arg
 prettyExpr (EParens expr) = parens $ prettyExpr expr
 

--- a/library/Amy/Syntax/BindingGroups.hs
+++ b/library/Amy/Syntax/BindingGroups.hs
@@ -1,0 +1,67 @@
+module Amy.Syntax.BindingGroups
+  ( bindingGroups
+  ) where
+
+import Data.Foldable (toList)
+import Data.Graph
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+import Amy.Syntax.AST
+
+--
+-- Binding Group
+--
+
+bindingGroups :: [Binding] -> [NonEmpty Binding]
+bindingGroups bindings =
+  let
+    bindingNames = Set.fromList $ locatedValue . bindingName <$> bindings
+    mkNode binding =
+      ( binding
+      , locatedValue (bindingName binding)
+      , Set.toList $ freeBindingVars binding `Set.intersection` bindingNames
+      )
+    nodes = mkNode <$> bindings
+    components' = stronglyConnComp nodes
+  in makeBindingGroup <$> components'
+
+makeBindingGroup :: SCC Binding -> NonEmpty Binding
+makeBindingGroup (AcyclicSCC binding) = binding :| []
+makeBindingGroup (CyclicSCC bindings) =
+  fromMaybe (error "Found empty CyclicSCC while computing binding groups")
+  $ NE.nonEmpty bindings
+
+--
+-- Free variables
+--
+
+freeBindingVars :: Binding -> Set IdentName
+freeBindingVars (Binding (Located _ name) args body) =
+  freeExprVars body `Set.difference` Set.fromList (name : (locatedValue <$> args))
+
+freeExprVars :: Expr -> Set IdentName
+freeExprVars ELit{} = Set.empty
+freeExprVars (ERecord _ rows) = Set.unions $ freeExprVars <$> Map.elems rows
+freeExprVars (ERecordSelect expr _) = freeExprVars expr
+freeExprVars (EVar (VVal (Located _ ident))) = Set.singleton ident
+freeExprVars (EVar VCons{}) = Set.empty
+freeExprVars (EIf (If pred' then' else' _)) = freeExprVars pred' `Set.union` freeExprVars then' `Set.union` freeExprVars else'
+freeExprVars (ECase (Case scrutinee matches _)) = Set.unions (freeExprVars scrutinee : toList (freeMatchVars <$> matches))
+ where
+  freeMatchVars (Match pat expr) = freeExprVars expr `Set.difference` patternVars pat
+freeExprVars (ELet (Let bindings expr _)) =
+  let bindings' = mapMaybe letBinding bindings
+  in Set.unions (freeExprVars expr : (freeBindingVars <$> bindings'))
+freeExprVars (EApp f arg) = freeExprVars f `Set.union` freeExprVars arg
+freeExprVars (EParens expr) = freeExprVars expr
+
+patternVars :: Pattern -> Set IdentName
+patternVars PLit{} = Set.empty
+patternVars (PVar (Located _ ident)) = Set.singleton ident
+patternVars (PCons (PatCons _ mPat)) = maybe Set.empty patternVars mPat
+patternVars (PParens pat) = patternVars pat

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -41,7 +41,7 @@ import Amy.Prim
 
 data Module
   = Module
-  { moduleBindings :: ![Binding]
+  { moduleBindings :: ![NonEmpty Binding]
   , moduleExterns :: ![Extern]
   , moduleTypeDeclarations :: ![TypeDeclaration]
   } deriving (Show, Eq)
@@ -138,7 +138,7 @@ data PatCons
 
 data Let
   = Let
-  { letBindings :: ![Binding]
+  { letBindings :: ![NonEmpty Binding]
   , letExpression :: !Expr
   } deriving (Show, Eq)
 

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -40,7 +40,7 @@ prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines
   $ (prettyExtern' <$> externs)
   ++ (prettyTypeDeclaration' <$> typeDeclarations)
-  ++ (prettyBinding' <$> bindings)
+  ++ (prettyBinding' <$> concat (toList <$> bindings))
 
 prettyExtern' :: Extern -> Doc ann
 prettyExtern' (Extern name ty) =
@@ -79,7 +79,7 @@ prettyExpr (ECase (Case scrutinee matches)) =
  where
   mkMatch (Match pat body) = (prettyPattern pat, prettyExpr body)
 prettyExpr (ELet (Let bindings body)) =
-  prettyLet (prettyBinding' <$> bindings) (prettyExpr body)
+  prettyLet (prettyBinding' <$> concat (toList <$> bindings)) (prettyExpr body)
 prettyExpr (EApp (App f arg _)) = prettyExpr f <+> prettyExpr arg
 prettyExpr (EParens expr) = parens $ prettyExpr expr
 


### PR DESCRIPTION
This allows type inference to properly compute the most general type for each binding. Also, binding group dependencies will be needed for lambda lifting.