### PR TITLE
Add tons of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ currently under heavy development, so if you happen to come across this repo
 please excuse the lack of documentation. There are however some examples of
 source code along with LLVM output in the
 [integration-tests](integration-tests/pass) directory.
+
+## Documentation
+
+See the [docs](docs/) directory for more thorough documentation. It contains
+both [user-facing documentation](docs/user-guide/README.md) and [compiler
+documentation](docs/compiler/README.md) for the `amy` compiler.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Amy Documentation
+
+This folder contains the documentation for the Amy programming language.
+
+* The [user-guide](user-guide/) directory contains user-facing documentation
+  about the language itself.
+* The [compiler](compiler/) directory contains internal documentation for the
+  `amy` compiler.

--- a/docs/compiler/README.md
+++ b/docs/compiler/README.md
@@ -1,0 +1,11 @@
+# Amy Compiler Documentation
+
+## Hacking on the compiler
+
+* [Getting Started](getting-started.md)
+* [Integration test suite](../../integration-tests/README.md)
+
+## Compiler architecture and algorithms
+
+* [Type Checker](type-checker.md)
+* [Runtime System](../../rts/README.md)

--- a/docs/compiler/getting-started.md
+++ b/docs/compiler/getting-started.md
@@ -1,0 +1,19 @@
+# Getting started with the compiler
+
+This document explains how to get started hacking on the `amy` compiler.
+
+## Requirements
+
+* Haskell development environment, preferably `stack`
+* LLVM development libraries, version 6 (`llvm-6.0-dev` on Ubuntu, see
+  http://apt.llvm.org/)
+* A recent version of `clang`, presumably the version packed with the LLVM
+  libraries you installed (`clang-6.0` on Ubuntu)
+* [Boehm Garbage Collector](http://www.hboehm.info/gc/) development libs.
+  (`libgc-dev` on Ubuntu)
+
+## Compiling the compiler
+
+Running `make test` should build the `amy` compiler and run all the integration
+tests. If you are missing a library like LLVM or `libgc`, surely this process
+will complain.

--- a/docs/compiler/type-checker.md
+++ b/docs/compiler/type-checker.md
@@ -1,0 +1,22 @@
+# Amy Type Checker
+
+This document explains the Amy type checking algorithm, and the work that
+inspired it.
+
+## Papers
+
+The Amy type checking algorithm is based on a few different papers:
+
+* [Complete and Easy Bidirectional Typechecking for Higher-Rank Polymorphism
+  (Dunfield 2013)](https://www.cl.cam.ac.uk/~nk480/bidir.pdf): This paper
+  describes the core of the Amy type checking algorithm. Everything else is
+  essentially added onto this core.
+* [Extensible records with scoped labels (Leijen
+  2005)](http://www.cs.ioc.ee/tfp-icfp-gpce05/tfp-proc/21num.pdf): This paper
+  describes a more thorough extensible implementation than the one we use (we
+  actually remove some features from this system).
+* [Typing Haskell in Haskell (Jones
+  2000)](https://web.cecs.pdx.edu/~mpj/thih/thih.pdf): This paper mainly
+  provided details about typing mutually recursive binding groups and binding
+  group dependency analysis. This useful information is surprisingly absent
+  from many academic type checking papers.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,4 @@
+# Amy User Guide
+
+* [Introduction](introduction.md)
+* [Difference from Haskell](differences-from-haskell.md)

--- a/docs/user-guide/differences-from-haskell.md
+++ b/docs/user-guide/differences-from-haskell.md
@@ -1,0 +1,87 @@
+# Differences from Haskell
+
+Amy is heavily inspired by Haskell and Haskell-like languages (like
+Purescript), as well as languages from the ML family (including OCaml).
+
+> **NOTE**: Amy is under heavy development, and many of the features
+> highlighted here might not be complete yet. See the [roadmap](roadmap.md) for
+> the current status of any in-progress features.
+
+## Criticisms of Haskell
+
+Haskell is a lazy functional programming language with a best-in-class type
+system. It holds a unique position in the programming language design space,
+and despite its age it has evolved remarkably well, producing numerous original
+contributions to programming languages in general.
+
+Haskell has been known as a hotbed of language and compiler research, and has
+accrued lots of new extensions and features during its lifetime. For better or
+for worse, Haskell also has to live with decisions that were made decades ago
+in the interest of backwards compatibility, decisions that might not live up to
+the lens of 20/20 hindsight today.
+
+We have the privilege of standing on the shoulders of giants, taking the best
+features of Haskell, combining them with unique new features, and culling any
+language design decisions that we don't like.
+
+### "Why does Haskell, in your opinion, suck?"
+
+There was a series of threads online in 2016 with variations on the theme of
+"What sucks about Haskell?".
+
+* Reddit: https://www.reddit.com/r/haskell/comments/4f47ou/why_does_haskell_in_your_opinion_suck/
+* Also Reddit: https://www.reddit.com/r/haskell/comments/4sihcv/haskell_the_bad_parts/
+* Hacker News: https://news.ycombinator.com/item?id=11513883
+
+While some comments there are a bit overzealous, there are nuggets of honest,
+constructive criticisms that inspired some of the directions taken in Amy. Feel
+free to read through those threads.
+
+In the rest of this document we will cover the specific differences between Amy
+and Haskell.
+
+## Strict Evaluation
+
+One key feature of Haskell is lazy evaluation by default. Values in Haskell are
+computed when they are needed, not when they are defined. Certainly, laziness
+is mind-blowing when you first learn about it. Laziness allows you to more
+easily compose algorithms as well. Laziness has greatly influenced the
+development of Haskell, and pretty much forced Haskell to stick to purity.
+
+Criticisms of lazy evaluation are all over the internet, but we highlight a few
+here:
+
+* Reasoning about the space/time complexity of code is more difficult.
+* Writing a lazy compiler that produces performant code is harder. (GHC is a
+  trailblazer in this space, and the optimizations it produces are astounding).
+* Interop with other languages that are not lazy is tougher.
+* This is a rather minor criticism, but laziness is something that is foreign
+  to most programmers, and the pitfalls of laziness are yet another thing to
+  learn.
+
+## Extensible Records
+
+Haskell's record system is rather rudimentary, and is a very commonly
+criticized component of the language. Amy uses a real extensible record system.
+
+TODO: Flesh this out with an example
+
+## Lack of advanced type system features
+
+Amy is focused on being **easy to learn** without sacrificing **power**. The
+language is kept as small as possible. This prevents proliferation of too many
+different idioms for doing the same thing. It also keeps the compiler smaller,
+easier to maintain, fast, and easier to optimize.
+
+It's really cool that Haskell's type system allows library authors to build
+libraries for things like extensible records, lenses for record updates, etc.
+However, in the interest of ease-of-use, learning, and quality error messages,
+we prefer to bake these into the language itself.
+
+## Module system
+
+> **NOTE**: This module system in particular is a work in progress.
+
+## Explicit `forall`
+
+TODO: Flesh this out

--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -1,0 +1,19 @@
+# The Amy Programming Language
+
+Amy is a strict, Haskell-like language that compiles to LLVM.
+
+## Features
+
+* **Powerful type system**: Static typing helps ensure programs are correct and
+  safe. Type systems should help you write software, not get in your way.
+* **Focus on simplicity and ease of learning**: This is not a grab-bag of
+  functional programming paradigms. The language focuses on being small and
+  easy to learn, yet still powerful.
+* **Strict evaluation**: Strict evaluation makes performance easier to reason
+  about, and it also makes it easier to write a compiler that produces
+  performant code.
+* **Compiles to LLVM**: Compilation to LLVM allows us to reap the benefits of
+  the LLVM toolchain, including advanced optimizations and targeting multiple
+  backends. This frees compiler developers to focus on the compiler frontend
+  instead of low-level details like register allocation and backend code
+  generation.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,17 @@
+# Amy Integration Test Suite
+
+This directory holds the integration test suite for the `amy` compiler.
+
+## Overview
+
+* Tests are defined in `tests.yaml`
+* Tests can technically be placed anywhere, but by convention we put passing
+  tests under `pass`, and failing tests under `fail`. That way we can point
+  users to passing tests as examples of `amy` programs, not failing tests.
+* `Main.hs` is the program that actually runs the tests. **It assumes that the
+  `amy` compiler is already built**.
+
+## Running tests
+
+The easiest way to run the test suite is via `make test` in the root of this
+repo. That ensures the compiler is built, and then it runs the tests.

--- a/rts/README.md
+++ b/rts/README.md
@@ -1,0 +1,81 @@
+# Runtime System
+
+Amy compiles to LLVM. One of the main goals is to take advantage of LLVM
+optimizations, and we can do that by using idiomatic LLVM. That means we
+shouldn't go crazy writing a ton of runtime system code to handle stacks, the
+heap, registers, etc. Code not written is code not maintained!
+
+Of course, we inevitably need _some_ runtime code. This document describes it.
+
+## Garbage collection
+
+We currently punt this to the [Boehm Garbage
+Collector](http://www.hboehm.info/gc/). Using this garbage collector is just
+too easy:
+
+* Link it into compiled programs with Clang via `-lgc`
+* Replace any uses of `malloc` with `GC_malloc`
+
+In the future we will need much more sophisticated accurate garbage collection,
+but this should do for now.
+
+Luckily Amy is strict. We will certainly do a lot less heap allocation than
+e.g. GHC/Haskell, which needs to do tons of allocations for thunks. Some
+allocation is totally unavoidable, as long as the language supports partial
+application and closures. Ideally the compiler can minimize the amount of heap
+allocation it has to do.
+
+## Closure conversion, eval/apply
+
+The closure conversion algorithm is inspired by the great paper [How to make a
+fast curry: push/enter vs eval/apply (Marlow/SPJ
+2004)](https://www.microsoft.com/en-us/research/publication/make-fast-curry-pushenter-vs-evalapply/).
+
+The key takeaways from this paper and how they apply to our closure conversion
+system are:
+
+* You can't look at a function type signature and know its arity. A function of
+  type `Int -> Int -> Int` could very well take two `Int`s and return another.
+  Or, it could take one `Int` and return a function that takes an `Int` and
+  returns an `Int`. It could even take zero arguments and just return a
+  function of `Int -> Int -> Int`!
+* You can't look at a function's type and know if it is partially applied or
+  not.
+* With the two previous points in mind, if we are applying arguments to an
+  unknown function (i.e. a function where we only know the type, like when a
+  function is passed as an argument to another function), **we can't know
+  exactly how many arguments to apply.**
+
+We use the eval/apply model of closure evaluation. In this model, we wrap up
+all closures in a struct that holds a pointer to the function, the function's
+arity, and already-applied arguments to the function (if any). When applying an
+unknown function, we first add all the arguments to the closure's array of
+arguments. Then, we check the length of the argument array against the arity:
+
+* If there are too many arguments, then we first apply the correct amount to
+  the function, and then we apply the remaining arguments to the function's
+  return value.
+* If there are just enough arguments, call the function and return the result.
+* If there are not enough arguments, then just return the closure as-is since
+  it is partially applied.
+
+There are some key implementation points to be made:
+
+* Known function calls can be optimized as a normal LLVM `call` to a known
+  global address. However, pretty much every other use of a function is assumed
+  to be working with a closure. In particular, every time we use a function as
+  an argument or return a function from a function, we wrap that sucker up in a
+  closure.
+* All values need to fit in however many bits we allocate for each element of
+  the argument array in closures (currently 64 bits via `int64_t` in C). This
+  might be made much more complicated once we have precise garbage collection.
+* It is very possible packing arguments into arrays and then unpacking them is
+  orders of magnitudes slower than keeping the latest arguments in registers
+  like GHC does.
+  1. The main strategy here is to hopefully optimize away closures in
+     performance sensitive code.
+  2. The current implementation is extremely simple, and we don't need to
+     generate dozens of premade functions for different call patterns like GHC
+     does. For now simplicity wins.
+  3. Once we have a respectable benchmark suite and regression tests, we can
+     optimize this much more.


### PR DESCRIPTION
This is long overdue.

I'm just using Markdown for now since Github renders that. Eventually we will probably need something like Sphinx.

I can flesh out a lot of the user-facing documentation later once the language design settles down slightly. My main goal currently is to record design decisions for the type checker and RTS while they are still fresh in my mind. Also, I have gotten asked about Amy a lot recently, so it's nice to point to an intro doc, and the "differences from Haskell" doc.