### PR TITLE
Eta expand primops and data constructors

### DIFF
--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -59,8 +59,13 @@ process filePath DumpFlags{..} input = do
     when dfDumpCore $
       lift $ writeFile (filePath `replaceExtension` ".amy-core") (show $ C.prettyModule core)
 
+    -- Prepare for ANF
+    let lifted = lambdaLifting core
+    when dfDumpCoreLifted $
+      lift $ writeFile (filePath `replaceExtension` ".amy-core-lifted") (show $ C.prettyModule lifted)
+
     -- Normalize to ANF
-    let anf = normalizeModule core
+    let anf = normalizeModule lifted
     when dfDumpANF $
       lift $ writeFile (filePath `replaceExtension` ".amy-anf") (show $ ANF.prettyModule anf)
 
@@ -136,6 +141,7 @@ data DumpFlags
   { dfDumpParsed :: !Bool
   , dfDumpTypeChecked :: !Bool
   , dfDumpCore :: !Bool
+  , dfDumpCoreLifted :: !Bool
   , dfDumpANF :: !Bool
   , dfDumpLLVMPretty :: !Bool
   --, dfDumpLLVM :: !Bool
@@ -167,6 +173,7 @@ parseDumpFlags =
   <$> switch (long "dump-parsed" <> helpDoc (Just "Dump parsed AST"))
   <*> switch (long "dump-typechecked" <> helpDoc (Just "Dump type checked AST"))
   <*> switch (long "dump-core" <> helpDoc (Just "Dump Core AST"))
+  <*> switch (long "dump-core-lifted" <> helpDoc (Just "Dump lifted Core AST"))
   <*> switch (long "dump-anf" <> helpDoc (Just "Dump ANF AST"))
   <*> switch (long "dump-llvm-pretty" <> helpDoc (Just "Dump pure LLVM AST from llvm-hs-pretty"))
   -- <*> switch (long "dump-llvm" <> helpDoc (Just "Dump LLVM IR"))

--- a/integration-tests/pass/funcargs/funcargs.amy
+++ b/integration-tests/pass/funcargs/funcargs.amy
@@ -1,10 +1,7 @@
 # Demonstrate use of a function as an argument
 
 main :: Int
-main = apply myAdd
+main = apply iAdd#
 
 apply :: (Int -> Int -> Int) -> Int
 apply f = f 1 2
-
-myAdd :: Int -> Int -> Int
-myAdd x y = iAdd# x y

--- a/integration-tests/pass/funcargs/funcargs.ll
+++ b/integration-tests/pass/funcargs/funcargs.ll
@@ -9,21 +9,15 @@ declare %struct.Closure* @call_closure(%struct.Closure*, i8, i64*)
 
 declare %struct.Closure* @create_closure(i8, %struct.Closure* (i64*)*)
 
-define private %struct.Closure* @myAdd_closure_wrapper(i64* %env) {
+define private %struct.Closure* @"lambda3_$4_closure_wrapper"(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
   %1 = load i64, i64* %0
   %2 = getelementptr i64, i64* %env, i32 1
   %3 = load i64, i64* %2
-  %4 = call i64 @myAdd(i64 %1, i64 %3)
+  %4 = call i64 @"lambda3_$4"(i64 %1, i64 %3)
   %5 = inttoptr i64 %4 to %struct.Closure*
   ret %struct.Closure* %5
-}
-
-define private i64 @myAdd(i64 %x, i64 %y) {
-entry:
-  %ret = add i64 %x, %y
-  ret i64 %ret
 }
 
 define private i64 @apply(%struct.Closure* %f) {
@@ -41,7 +35,13 @@ entry:
 
 define i64 @main() {
 entry:
-  %myAdd_closure1 = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @myAdd_closure_wrapper)
-  %ret = call i64 @apply(%struct.Closure* %myAdd_closure1)
+  %"lambda3_$4_closure1" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda3_$4_closure_wrapper")
+  %ret = call i64 @apply(%struct.Closure* %"lambda3_$4_closure1")
+  ret i64 %ret
+}
+
+define private i64 @"lambda3_$4"(i64 %_x1, i64 %_x2) {
+entry:
+  %ret = add i64 %_x1, %_x2
   ret i64 %ret
 }

--- a/integration-tests/pass/lambda-lift/lambda-lift.amy
+++ b/integration-tests/pass/lambda-lift/lambda-lift.amy
@@ -14,7 +14,7 @@ main =
 
     # Needs closing
     z = 2
-    f = \x -> iAdd# z x
+    f = iAdd# z
 
     # Mutually recursive, and needs closing
     a = 1

--- a/integration-tests/pass/lambda-lift/lambda-lift.amy
+++ b/integration-tests/pass/lambda-lift/lambda-lift.amy
@@ -1,5 +1,7 @@
 # Demonstrate lambda lifting
 
+Maybe a = Nothing | Just a
+
 main :: Int
 main =
   let
@@ -21,3 +23,6 @@ main =
     g x = if iLessThan# x 0 then 100 else g' (iSub# x z)
     g' x = g ((\y -> iAdd# x y) a)
   in g (f (const 2 1))
+
+mkJust :: forall a. a -> Maybe a
+mkJust = Just

--- a/integration-tests/pass/lambda-lift/lambda-lift.ll
+++ b/integration-tests/pass/lambda-lift/lambda-lift.ll
@@ -2,6 +2,7 @@
 source_filename = "<string>"
 
 %struct.Closure = type { i8, %struct.Closure* (i64*)*, i8, i64* }
+%Maybe = type { i1, i64* }
 
 declare i8* @GC_malloc(i64)
 
@@ -9,26 +10,45 @@ declare %struct.Closure* @call_closure(%struct.Closure*, i8, i64*)
 
 declare %struct.Closure* @create_closure(i8, %struct.Closure* (i64*)*)
 
-define private %struct.Closure* @"lambda4_$5_closure_wrapper"(i64* %env) {
+define private %struct.Closure* @"lambda12_$13_closure_wrapper"(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
   %1 = load i64, i64* %0
   %2 = getelementptr i64, i64* %env, i32 1
   %3 = load i64, i64* %2
-  %4 = call i64 @"lambda4_$5"(i64 %1, i64 %3)
+  %4 = call i64 @"lambda12_$13"(i64 %1, i64 %3)
   %5 = inttoptr i64 %4 to %struct.Closure*
   ret %struct.Closure* %5
 }
 
-define private %struct.Closure* @"lambda9_$10_closure_wrapper"(i64* %env) {
+define private %struct.Closure* @"lambda2_$3_closure_wrapper"(i64* %env) {
+entry:
+  %0 = getelementptr i64, i64* %env, i32 0
+  %1 = bitcast i64* %0 to i64**
+  %2 = load i64*, i64** %1
+  %3 = call %Maybe* @"lambda2_$3"(i64* %2)
+  %4 = bitcast %Maybe* %3 to %struct.Closure*
+  ret %struct.Closure* %4
+}
+
+define private %struct.Closure* @"lambda7_$8_closure_wrapper"(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
   %1 = load i64, i64* %0
   %2 = getelementptr i64, i64* %env, i32 1
   %3 = load i64, i64* %2
-  %4 = call i64 @"lambda9_$10"(i64 %1, i64 %3)
+  %4 = call i64 @"lambda7_$8"(i64 %1, i64 %3)
   %5 = inttoptr i64 %4 to %struct.Closure*
   ret %struct.Closure* %5
+}
+
+define private %struct.Closure* @mkJust() {
+entry:
+  %"lambda2_$3_closure1" = call %struct.Closure* @create_closure(i8 1, %struct.Closure* (i64*)* @"lambda2_$3_closure_wrapper")
+  %0 = alloca %struct.Closure*
+  store %struct.Closure* %"lambda2_$3_closure1", %struct.Closure** %0
+  %ret = load %struct.Closure*, %struct.Closure** %0
+  ret %struct.Closure* %ret
 }
 
 define i64 @main() {
@@ -36,30 +56,42 @@ entry:
   %0 = alloca i64
   store i64 2, i64* %0
   %z = load i64, i64* %0
-  %"lambda4_$5_closure1" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda4_$5_closure_wrapper")
+  %"lambda7_$8_closure2" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda7_$8_closure_wrapper")
   %1 = call i8* @GC_malloc(i64 64)
   %2 = bitcast i8* %1 to i64*
   %3 = getelementptr i64, i64* %2, i32 0
   store i64 %z, i64* %3
-  %4 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda4_$5_closure1", i8 1, i64* %2)
+  %4 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda7_$8_closure2", i8 1, i64* %2)
   %5 = alloca %struct.Closure*
   store %struct.Closure* %4, %struct.Closure** %5
   %f = load %struct.Closure*, %struct.Closure** %5
   %6 = alloca i64
   store i64 1, i64* %6
   %a = load i64, i64* %6
-  %res2 = call i64 @"const_$6"(i64 2, i64 1)
+  %res3 = call i64 @"const_$9"(i64 2, i64 1)
   %7 = call i8* @GC_malloc(i64 64)
   %8 = bitcast i8* %7 to i64*
   %9 = getelementptr i64, i64* %8, i32 0
-  store i64 %res2, i64* %9
+  store i64 %res3, i64* %9
   %10 = call %struct.Closure* @call_closure(%struct.Closure* %f, i8 1, i64* %8)
-  %res3 = ptrtoint %struct.Closure* %10 to i64
-  %ret = call i64 @"g_$8"(i64 %a, i64 %z, i64 %res3)
+  %res4 = ptrtoint %struct.Closure* %10 to i64
+  %ret = call i64 @"g_$11"(i64 %a, i64 %z, i64 %res4)
   ret i64 %ret
 }
 
-define private i64 @"id'_$2"(i64 %x, i64 %y) {
+define private %Maybe* @"lambda2_$3"(i64* %_x1) {
+entry:
+  %0 = call i8* @GC_malloc(i64 ptrtoint (%Maybe* getelementptr (%Maybe, %Maybe* null, i32 1) to i64))
+  %ret = bitcast i8* %0 to %Maybe*
+  %ret1 = alloca %Maybe
+  %1 = getelementptr %Maybe, %Maybe* %ret1, i32 0, i32 0
+  store i1 true, i1* %1
+  %2 = getelementptr %Maybe, %Maybe* %ret1, i32 0, i32 1
+  store i64* %_x1, i64** %2
+  ret %Maybe* %ret1
+}
+
+define private i64 @"id'_$5"(i64 %x, i64 %y) {
 entry:
   %0 = alloca i64
   store i64 %x, i64* %0
@@ -67,55 +99,55 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @"id_$1"(i64 %x) {
+define private i64 @"id_$4"(i64 %x) {
 entry:
-  %ret = call i64 @"id'_$2"(i64 %x, i64 %x)
+  %ret = call i64 @"id'_$5"(i64 %x, i64 %x)
   ret i64 %ret
 }
 
-define private i64 @"lambda4_$5"(i64 %z, i64 %_x3) {
+define private i64 @"lambda7_$8"(i64 %z, i64 %_x6) {
 entry:
-  %ret = add i64 %z, %_x3
+  %ret = add i64 %z, %_x6
   ret i64 %ret
 }
 
-define private i64 @"const_$6"(i64 %x, i64 %y) {
+define private i64 @"const_$9"(i64 %x, i64 %y) {
 entry:
-  %ret = call i64 @"id_$1"(i64 %y)
+  %ret = call i64 @"id_$4"(i64 %y)
   ret i64 %ret
 }
 
-define private i64 @"lambda9_$10"(i64 %x, i64 %y) {
+define private i64 @"lambda12_$13"(i64 %x, i64 %y) {
 entry:
   %ret = add i64 %x, %y
   ret i64 %ret
 }
 
-define private i64 @"g'_$7"(i64 %a, i64 %z, i64 %x) {
+define private i64 @"g'_$10"(i64 %a, i64 %z, i64 %x) {
 entry:
-  %"lambda9_$10_closure4" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda9_$10_closure_wrapper")
+  %"lambda12_$13_closure5" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda12_$13_closure_wrapper")
   %0 = call i8* @GC_malloc(i64 64)
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i32 0
   store i64 %x, i64* %2
-  %3 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda9_$10_closure4", i8 1, i64* %1)
+  %3 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda12_$13_closure5", i8 1, i64* %1)
   %4 = alloca %struct.Closure*
   store %struct.Closure* %3, %struct.Closure** %4
-  %res5 = load %struct.Closure*, %struct.Closure** %4
+  %res6 = load %struct.Closure*, %struct.Closure** %4
   %5 = call i8* @GC_malloc(i64 64)
   %6 = bitcast i8* %5 to i64*
   %7 = getelementptr i64, i64* %6, i32 0
   store i64 %a, i64* %7
-  %8 = call %struct.Closure* @call_closure(%struct.Closure* %res5, i8 1, i64* %6)
-  %res6 = ptrtoint %struct.Closure* %8 to i64
-  %ret = call i64 @"g_$8"(i64 %a, i64 %z, i64 %res6)
+  %8 = call %struct.Closure* @call_closure(%struct.Closure* %res6, i8 1, i64* %6)
+  %res7 = ptrtoint %struct.Closure* %8 to i64
+  %ret = call i64 @"g_$11"(i64 %a, i64 %z, i64 %res7)
   ret i64 %ret
 }
 
-define private i64 @"g_$8"(i64 %a, i64 %z, i64 %x) {
+define private i64 @"g_$11"(i64 %a, i64 %z, i64 %x) {
 entry:
-  %res7 = icmp slt i64 %x, 0
-  switch i1 %res7, label %case.0.ret [
+  %res8 = icmp slt i64 %x, 0
+  switch i1 %res8, label %case.0.ret [
     i1 true, label %case.0.ret
     i1 false, label %case.1.ret
   ]
@@ -127,8 +159,8 @@ case.0.ret:                                       ; preds = %entry, %entry
   br label %case.end.ret
 
 case.1.ret:                                       ; preds = %entry
-  %res8 = sub i64 %x, %z
-  %2 = call i64 @"g'_$7"(i64 %a, i64 %z, i64 %res8)
+  %res9 = sub i64 %x, %z
+  %2 = call i64 @"g'_$10"(i64 %a, i64 %z, i64 %res9)
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret

--- a/integration-tests/pass/lambda-lift/lambda-lift.ll
+++ b/integration-tests/pass/lambda-lift/lambda-lift.ll
@@ -9,24 +9,24 @@ declare %struct.Closure* @call_closure(%struct.Closure*, i8, i64*)
 
 declare %struct.Closure* @create_closure(i8, %struct.Closure* (i64*)*)
 
-define private %struct.Closure* @"lambda3_$4_closure_wrapper"(i64* %env) {
+define private %struct.Closure* @"lambda4_$5_closure_wrapper"(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
   %1 = load i64, i64* %0
   %2 = getelementptr i64, i64* %env, i32 1
   %3 = load i64, i64* %2
-  %4 = call i64 @"lambda3_$4"(i64 %1, i64 %3)
+  %4 = call i64 @"lambda4_$5"(i64 %1, i64 %3)
   %5 = inttoptr i64 %4 to %struct.Closure*
   ret %struct.Closure* %5
 }
 
-define private %struct.Closure* @"lambda8_$9_closure_wrapper"(i64* %env) {
+define private %struct.Closure* @"lambda9_$10_closure_wrapper"(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
   %1 = load i64, i64* %0
   %2 = getelementptr i64, i64* %env, i32 1
   %3 = load i64, i64* %2
-  %4 = call i64 @"lambda8_$9"(i64 %1, i64 %3)
+  %4 = call i64 @"lambda9_$10"(i64 %1, i64 %3)
   %5 = inttoptr i64 %4 to %struct.Closure*
   ret %struct.Closure* %5
 }
@@ -36,26 +36,26 @@ entry:
   %0 = alloca i64
   store i64 2, i64* %0
   %z = load i64, i64* %0
-  %"lambda3_$4_closure1" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda3_$4_closure_wrapper")
+  %"lambda4_$5_closure1" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda4_$5_closure_wrapper")
   %1 = call i8* @GC_malloc(i64 64)
   %2 = bitcast i8* %1 to i64*
   %3 = getelementptr i64, i64* %2, i32 0
   store i64 %z, i64* %3
-  %4 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda3_$4_closure1", i8 1, i64* %2)
+  %4 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda4_$5_closure1", i8 1, i64* %2)
   %5 = alloca %struct.Closure*
   store %struct.Closure* %4, %struct.Closure** %5
   %f = load %struct.Closure*, %struct.Closure** %5
   %6 = alloca i64
   store i64 1, i64* %6
   %a = load i64, i64* %6
-  %res2 = call i64 @"const_$5"(i64 2, i64 1)
+  %res2 = call i64 @"const_$6"(i64 2, i64 1)
   %7 = call i8* @GC_malloc(i64 64)
   %8 = bitcast i8* %7 to i64*
   %9 = getelementptr i64, i64* %8, i32 0
   store i64 %res2, i64* %9
   %10 = call %struct.Closure* @call_closure(%struct.Closure* %f, i8 1, i64* %8)
   %res3 = ptrtoint %struct.Closure* %10 to i64
-  %ret = call i64 @"g_$7"(i64 %a, i64 %z, i64 %res3)
+  %ret = call i64 @"g_$8"(i64 %a, i64 %z, i64 %res3)
   ret i64 %ret
 }
 
@@ -73,32 +73,32 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @"lambda3_$4"(i64 %z, i64 %x) {
+define private i64 @"lambda4_$5"(i64 %z, i64 %_x3) {
 entry:
-  %ret = add i64 %z, %x
+  %ret = add i64 %z, %_x3
   ret i64 %ret
 }
 
-define private i64 @"const_$5"(i64 %x, i64 %y) {
+define private i64 @"const_$6"(i64 %x, i64 %y) {
 entry:
   %ret = call i64 @"id_$1"(i64 %y)
   ret i64 %ret
 }
 
-define private i64 @"lambda8_$9"(i64 %x, i64 %y) {
+define private i64 @"lambda9_$10"(i64 %x, i64 %y) {
 entry:
   %ret = add i64 %x, %y
   ret i64 %ret
 }
 
-define private i64 @"g'_$6"(i64 %a, i64 %z, i64 %x) {
+define private i64 @"g'_$7"(i64 %a, i64 %z, i64 %x) {
 entry:
-  %"lambda8_$9_closure4" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda8_$9_closure_wrapper")
+  %"lambda9_$10_closure4" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda9_$10_closure_wrapper")
   %0 = call i8* @GC_malloc(i64 64)
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i32 0
   store i64 %x, i64* %2
-  %3 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda8_$9_closure4", i8 1, i64* %1)
+  %3 = call %struct.Closure* @call_closure(%struct.Closure* %"lambda9_$10_closure4", i8 1, i64* %1)
   %4 = alloca %struct.Closure*
   store %struct.Closure* %3, %struct.Closure** %4
   %res5 = load %struct.Closure*, %struct.Closure** %4
@@ -108,11 +108,11 @@ entry:
   store i64 %a, i64* %7
   %8 = call %struct.Closure* @call_closure(%struct.Closure* %res5, i8 1, i64* %6)
   %res6 = ptrtoint %struct.Closure* %8 to i64
-  %ret = call i64 @"g_$7"(i64 %a, i64 %z, i64 %res6)
+  %ret = call i64 @"g_$8"(i64 %a, i64 %z, i64 %res6)
   ret i64 %ret
 }
 
-define private i64 @"g_$7"(i64 %a, i64 %z, i64 %x) {
+define private i64 @"g_$8"(i64 %a, i64 %z, i64 %x) {
 entry:
   %res7 = icmp slt i64 %x, 0
   switch i1 %res7, label %case.0.ret [
@@ -128,7 +128,7 @@ case.0.ret:                                       ; preds = %entry, %entry
 
 case.1.ret:                                       ; preds = %entry
   %res8 = sub i64 %x, %z
-  %2 = call i64 @"g'_$6"(i64 %a, i64 %z, i64 %res8)
+  %2 = call i64 @"g'_$7"(i64 %a, i64 %z, i64 %res8)
   br label %case.end.ret
 
 case.end.ret:                                     ; preds = %case.1.ret, %case.0.ret

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -16,14 +16,11 @@ import Data.Traversable (for)
 import Amy.ANF.AST as ANF
 import Amy.ANF.Monad
 import Amy.Core.AST as C
-import Amy.Core.LambdaLift
 import Amy.Prim
 
 normalizeModule :: C.Module -> ANF.Module
-normalizeModule mod' =
+normalizeModule (C.Module bindingGroups externs typeDeclarations) =
   let
-    -- First do lambda lifting
-    (C.Module bindingGroups externs typeDeclarations) = lambdaLifting mod'
     bindings = concatMap NE.toList bindingGroups
 
     -- Record top-level names

--- a/library/Amy/Core.hs
+++ b/library/Amy/Core.hs
@@ -4,4 +4,5 @@ module Amy.Core
 
 import Amy.Core.AST as X
 import Amy.Core.Desugar as X
+import Amy.Core.LambdaLift as X
 import Amy.Core.Pretty as X

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -31,6 +31,7 @@ module Amy.Core.AST
 
   , Type(..)
   , unfoldTyApp
+  , unfoldTyFun
   , Typed(..)
 
     -- Re-export

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -181,10 +181,12 @@ data App
   , appReturnType :: !Type
   } deriving (Show, Eq)
 
+-- | Unfold an 'App' node into function and args.
 unfoldApp :: App -> NonEmpty Expr
 unfoldApp (App (EApp app@App{}) arg _) = unfoldApp app <> (arg :| [])
 unfoldApp (App f arg _) = f :| [arg]
 
+-- | Combine function and arg expressions into an 'App' node.
 foldApp :: Expr -> [Expr] -> Expr
 foldApp func args =
   let

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -19,6 +19,7 @@ module Amy.Core.AST
   , Lambda(..)
   , App(..)
   , unfoldApp
+  , foldApp
   , expressionType
   , substExpr
   , traverseExprTopDown
@@ -39,6 +40,7 @@ module Amy.Core.AST
   ) where
 
 import Control.Monad.Identity (Identity(..), runIdentity)
+import Data.List (foldl', tails)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -182,6 +184,17 @@ unfoldApp :: App -> NonEmpty Expr
 unfoldApp (App (EApp app@App{}) arg _) = unfoldApp app <> (arg :| [])
 unfoldApp (App f arg _) = f :| [arg]
 
+foldApp :: Expr -> [Expr] -> Expr
+foldApp func args =
+  let
+    tys = unfoldTyFun $ expressionType func
+    appTys = NE.drop 1 tys
+    varsAndTys = zip args $ tails appTys
+  in foldl' mkApp func varsAndTys
+ where
+  mkApp :: Expr -> (Expr, [Type]) -> Expr
+  mkApp e (arg, tys') = EApp $ App e arg (foldr1 TyFun tys')
+
 literalType' :: Literal -> Type
 literalType' lit = TyCon $ literalType lit
 
@@ -320,6 +333,11 @@ unfoldTyApp :: Type -> NonEmpty Type
 unfoldTyApp (TyApp app@(TyApp _ _) arg) = unfoldTyApp app <> (arg :| [])
 unfoldTyApp (TyApp f arg) = f :| [arg]
 unfoldTyApp t = t :| []
+
+unfoldTyFun :: Type -> NonEmpty Type
+unfoldTyFun (TyForall _ t) = unfoldTyFun t
+unfoldTyFun (t1 `TyFun` t2) = NE.cons t1 (unfoldTyFun t2)
+unfoldTyFun ty = ty :| []
 
 data Typed a
   = Typed

--- a/library/Amy/Core/LambdaLift.hs
+++ b/library/Amy/Core/LambdaLift.hs
@@ -251,7 +251,7 @@ maybeEtaExpandExpr expr@(EVar (VVal (Typed _ func))) args mRetTy =
   $ Map.lookup func primitiveFunctionsByName
 maybeEtaExpandExpr expr@(EVar (VCons (Typed ty _))) args mRetTy = do
   let
-    allArgTys = NE.init $ unfoldTyApp ty
+    allArgTys = NE.init $ unfoldTyFun ty
     argTys = drop (length args) allArgTys
   etaExpand expr args mRetTy argTys
 maybeEtaExpandExpr expr args mRetTy = do


### PR DESCRIPTION
This was an unfinished part of closure conversion.

Partially applied primitive operations and data constructors need to be eta expanded so they are saturated. That way we never have to apply closures to them. This keeps closure conversion code simple because closures will only contain functions, not special code for primops or data constructors.

I'll probably refactor this code a bit, I'm not super happy with it. Too many weird special cases to prevent infinite recursion.