### PR TITLE
Deduplicate across ASTs

### DIFF
--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -83,6 +83,7 @@ convertType ty = go (typeToNonEmpty ty)
     case ty' of
       C.TyCon con -> getTyConType con
       C.TyVar _ -> pure OpaquePointerType
+      C.TyExistVar _ -> error "Found TyExistVar in Core"
       app@C.TyApp{} ->
         case unfoldTyApp app of
           TyCon con :| _ -> getTyConType con
@@ -91,6 +92,7 @@ convertType ty = go (typeToNonEmpty ty)
       C.TyRecord rows _ -> mkRecordType rows
       C.TyFun{} -> pure ClosureType
       C.TyForall _ ty'' -> convertType ty''
+      C.LocatedType _ _ -> error "Found LocatedType in Core"
   go _ = pure ClosureType
 
 mkRecordType :: Map RowLabel C.Type -> ANFConvert ANF.Type

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -54,10 +54,10 @@ convertTypeDeclaration :: C.TypeDeclaration -> ANFConvert ANF.TypeDeclaration
 convertTypeDeclaration (C.TypeDeclaration tyConDef con) = do
   ty <- getTyConDefinitionType tyConDef
   con' <- traverse convertDataConDefinition con
-  pure $ ANF.TypeDeclaration (C.tyConDefinitionName tyConDef) ty con'
+  pure $ ANF.TypeDeclaration (locatedValue $ C.tyConDefinitionName tyConDef) ty con'
 
 convertDataConDefinition :: C.DataConDefinition -> ANFConvert ANF.DataConDefinition
-convertDataConDefinition (C.DataConDefinition conName mTyArg) = do
+convertDataConDefinition (C.DataConDefinition (Located _ conName) mTyArg) = do
   mTyArg' <- traverse convertType mTyArg
   pure
     ANF.DataConDefinition

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -10,7 +10,7 @@ import Data.Maybe (maybeToList)
 import qualified Data.Map.Strict as Map
 
 import Amy.ANF.AST
-import Amy.Pretty
+import Amy.Pretty hiding (prettyType)
 import Amy.Prim
 
 prettyType :: Type -> Doc ann

--- a/library/Amy/ANF/TypeRep.hs
+++ b/library/Amy/ANF/TypeRep.hs
@@ -32,7 +32,7 @@ typeRep (C.TypeDeclaration tyName constructors) =
       if all (isNothing . C.dataConDefinitionArgument) constructors
       then EnumType wordSize
       -- Can't do an enum. We'll have to use tagged pairs.
-      else TaggedUnionType (tyConDefinitionName tyName) wordSize
+      else TaggedUnionType (locatedValue $ tyConDefinitionName tyName) wordSize
  where
   -- Pick a proper integer size
   wordSize :: Word32
@@ -42,7 +42,7 @@ typeRep (C.TypeDeclaration tyName constructors) =
       | otherwise -> 32
 
 maybePrimitiveType :: C.TyConDefinition -> Maybe ANF.Type
-maybePrimitiveType (C.TyConDefinition name _)
+maybePrimitiveType (C.TyConDefinition (Located _ name) _)
   -- TODO: Something more robust here besides text name matching.
   | name == "Int" = Just PrimIntType
   | name == "Double" = Just PrimDoubleType

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -24,9 +24,9 @@ module Amy.Core.AST
 
     -- Re-export
   , Literal(..)
-  , Located(..)
   , module Amy.ASTCommon
   , module Amy.Names
+  , module Amy.Syntax.Located
   , module Amy.Type
   ) where
 
@@ -155,12 +155,9 @@ foldApp func args =
   mkApp :: Expr -> (Expr, [Type]) -> Expr
   mkApp e (arg, tys') = EApp $ App e arg (foldr1 TyFun tys')
 
-literalType' :: Literal -> Type
-literalType' lit = TyCon $ literalType lit
-
 expressionType :: Expr -> Type
-expressionType (ELit lit) = literalType' lit
-expressionType (ERecord rows) = TyRecord (typedType <$> rows) Nothing
+expressionType (ELit lit) = literalType lit
+expressionType (ERecord rows) = TyRecord (Map.mapKeys notLocated $ typedType <$> rows) Nothing
 expressionType (ERecordSelect _ _ ty) = ty
 expressionType (EVar (Typed ty _)) = ty
 expressionType (ECon (Typed ty _)) = ty

--- a/library/Amy/Core/AST.hs
+++ b/library/Amy/Core/AST.hs
@@ -2,10 +2,6 @@ module Amy.Core.AST
   ( Module(..)
   , Binding(..)
   , Extern(..)
-  , TypeDeclaration(..)
-  , TyConDefinition(..)
-  , fromPrimTypeDefinition
-  , DataConDefinition(..)
   , Expr(..)
   , If(..)
   , Case(..)
@@ -28,6 +24,7 @@ module Amy.Core.AST
 
     -- Re-export
   , Literal(..)
+  , Located(..)
   , module Amy.ASTCommon
   , module Amy.Names
   , module Amy.Type
@@ -47,7 +44,6 @@ import Amy.ASTCommon
 import Amy.Literal
 import Amy.Names
 import Amy.Prim
-import qualified Amy.Syntax.AST as S
 import Amy.Syntax.Located
 import Amy.Type
 
@@ -75,35 +71,6 @@ data Extern
   { externName :: !IdentName
   , externType :: !Type
   } deriving (Show, Eq)
-
-data TypeDeclaration
-  = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConDefinition
-  , typeDeclarationConstructors :: ![DataConDefinition]
-  } deriving (Show, Eq, Ord)
-
-data TyConDefinition
-  = TyConDefinition
-  { tyConDefinitionName :: !TyConName
-  , tyConDefinitionArgs :: ![TyVarName]
-  } deriving (Show, Eq, Ord)
-
-fromPrimTyDef :: S.TyConDefinition -> TyConDefinition
-fromPrimTyDef (S.TyConDefinition (Located _ name) args) = TyConDefinition name (locatedValue <$> args)
-
-fromPrimTypeDefinition :: S.TypeDeclaration -> TypeDeclaration
-fromPrimTypeDefinition (S.TypeDeclaration tyConDef dataCons) =
-  TypeDeclaration (fromPrimTyDef tyConDef) (fromPrimDataCon <$> dataCons)
-
-data DataConDefinition
-  = DataConDefinition
-  { dataConDefinitionName :: !DataConName
-  , dataConDefinitionArgument :: !(Maybe Type)
-  } deriving (Show, Eq, Ord)
-
-fromPrimDataCon :: S.DataConDefinition -> DataConDefinition
-fromPrimDataCon (S.DataConDefinition (Located _ name) Nothing) = DataConDefinition name Nothing
-fromPrimDataCon (S.DataConDefinition _ (Just _)) = error "Couldn't convert data con definiton type."
 
 data Expr
   = ELit !Literal

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -8,8 +8,6 @@ import Data.List (foldl')
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (maybeToList)
-import Data.Monoid ((<>))
-import Data.Text (pack)
 
 import Amy.Core.AST as C
 import Amy.Core.Monad
@@ -110,15 +108,8 @@ desugarExpr (T.EParens expr) = C.EParens <$> desugarExpr expr
 desugarTypedIdent :: T.Typed IdentName -> C.Typed IdentName
 desugarTypedIdent (T.Typed ty ident) = C.Typed (desugarType ty) ident
 
-desugarType :: T.Type -> C.Type
-desugarType (T.TyCon con) = C.TyCon con
-desugarType (T.TyRecord rows mTail) = C.TyRecord (desugarType <$> rows) (desugarType <$> mTail)
-desugarType (T.TyVar var) = C.TyVar var
-desugarType (T.TyExistVar (TyExistVarName i)) = C.TyVar $ TyVarName $ "$t" <> pack (show i)
-desugarType (T.TyApp f arg) = C.TyApp (desugarType f) (desugarType arg)
-desugarType (T.TyFun ty1 ty2) = C.TyFun (desugarType ty1) (desugarType ty2)
-desugarType (T.TyForall vars ty) = C.TyForall vars (desugarType ty)
-desugarType (LocatedType _ ty) = desugarType ty
+desugarType :: Type -> Type
+desugarType = removeLocatedType . removeTyExistVar
 
 desugarTyConDefinition :: T.TyConDefinition -> C.TyConDefinition
 desugarTyConDefinition (T.TyConDefinition name args) = C.TyConDefinition name args

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -28,7 +28,7 @@ desugarExtern (T.Extern ident ty) = C.Extern ident (desugarType ty)
 
 desugarTypeDeclaration :: T.TypeDeclaration -> C.TypeDeclaration
 desugarTypeDeclaration (T.TypeDeclaration tyName cons) =
-  C.TypeDeclaration (desugarTyConDefinition tyName) (desugarDataConDefinition <$> cons)
+  C.TypeDeclaration tyName (desugarDataConDefinition <$> cons)
 
 desugarDataConDefinition :: T.DataConDefinition -> C.DataConDefinition
 desugarDataConDefinition (T.DataConDefinition conName mTyArg) =
@@ -111,9 +111,6 @@ desugarTypedIdent (T.Typed ty ident) = C.Typed (desugarType ty) ident
 desugarType :: Type -> Type
 desugarType = removeLocatedType . removeTyExistVar
 
-desugarTyConDefinition :: T.TyConDefinition -> C.TyConDefinition
-desugarTyConDefinition (T.TyConDefinition name args) = C.TyConDefinition name args
-
 --
 -- Case Expressions
 --
@@ -160,7 +157,7 @@ restoreClause clause@(PC.Clause (PC.ConLit _) _ _) =
 restoreClause (PC.Clause (PC.Con con _ _) args caseExpr) = do
   (tyDecl, _) <- lookupDataConType con
   let
-    patTy = C.TyCon $ C.tyConDefinitionName $ C.typeDeclarationTypeName tyDecl
+    patTy = C.TyCon $ locatedValue $ C.tyConDefinitionName $ C.typeDeclarationTypeName tyDecl
     arg =
       case args of
         [] -> Nothing

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -118,6 +118,7 @@ desugarType (T.TyExistVar (TyExistVarName i)) = C.TyVar $ TyVarName $ "$t" <> pa
 desugarType (T.TyApp f arg) = C.TyApp (desugarType f) (desugarType arg)
 desugarType (T.TyFun ty1 ty2) = C.TyFun (desugarType ty1) (desugarType ty2)
 desugarType (T.TyForall vars ty) = C.TyForall vars (desugarType ty)
+desugarType (LocatedType _ ty) = desugarType ty
 
 desugarTyConDefinition :: T.TyConDefinition -> C.TyConDefinition
 desugarTyConDefinition (T.TyConDefinition name args) = C.TyConDefinition name args

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -86,7 +86,7 @@ desugarExpr (T.ELam (T.Lambda args body ty)) = do
   pure $ C.ELam $ C.Lambda args' body' ty'
 desugarExpr (T.EIf (T.If pred' then' else')) =
   let
-    boolTyCon' = TyCon boolTyCon
+    boolTyCon' = TyCon (notLocated boolTyCon)
     mkBoolPatCons cons = T.PatCons cons Nothing boolTyCon'
     matches =
       NE.fromList
@@ -109,7 +109,7 @@ desugarTypedIdent :: Typed IdentName -> Typed IdentName
 desugarTypedIdent (Typed ty ident) = Typed (desugarType ty) ident
 
 desugarType :: Type -> Type
-desugarType = removeLocatedType . removeTyExistVar
+desugarType = removeTyExistVar
 
 --
 -- Case Expressions
@@ -157,7 +157,7 @@ restoreClause clause@(PC.Clause (PC.ConLit _) _ _) =
 restoreClause (PC.Clause (PC.Con con _ _) args caseExpr) = do
   (tyDecl, _) <- lookupDataConType con
   let
-    patTy = TyCon $ locatedValue $ tyConDefinitionName $ typeDeclarationTypeName tyDecl
+    patTy = TyCon $ fromLocated $ tyConDefinitionName $ typeDeclarationTypeName tyDecl
     arg =
       case args of
         [] -> Nothing

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -7,6 +7,7 @@ module Amy.Core.Desugar
 import Data.List (foldl')
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
 import Data.Maybe (maybeToList)
 
 import Amy.Core.AST as C
@@ -24,7 +25,7 @@ desugarModule (T.Module bindings externs typeDeclarations) = do
     pure $ C.Module bindings' externs' typeDeclarations'
 
 desugarExtern :: T.Extern -> C.Extern
-desugarExtern (T.Extern ident ty) = C.Extern ident (desugarType ty)
+desugarExtern (T.Extern (Located _ ident) ty) = C.Extern ident (desugarType ty)
 
 desugarTypeDeclaration :: TypeDeclaration -> TypeDeclaration
 desugarTypeDeclaration (TypeDeclaration tyName cons) =
@@ -38,25 +39,27 @@ desugarDataConDefinition (DataConDefinition conName mTyArg) =
   }
 
 desugarBinding :: T.Binding -> Desugar C.Binding
-desugarBinding (T.Binding ident ty args retTy body) =
+desugarBinding (T.Binding (Located _ ident) ty args retTy body) =
   C.Binding
     ident
     (desugarType ty)
-    (desugarTypedIdent <$> args)
+    (desugarTypedIdent . fmap locatedValue <$> args)
     (desugarType retTy)
     <$> desugarExpr body
 
 desugarExpr :: T.Expr -> Desugar C.Expr
-desugarExpr (T.ELit lit) = pure $ C.ELit lit
+desugarExpr (T.ELit (Located _ lit)) = pure $ C.ELit lit
 desugarExpr (T.ERecord rows) =
-  C.ERecord <$> traverse (\(Typed ty expr) -> Typed (desugarType ty) <$> desugarExpr expr) rows
-desugarExpr (T.ERecordSelect expr label ty) = do
+  C.ERecord
+  . Map.mapKeys locatedValue
+  <$> traverse (\(Typed ty expr) -> Typed (desugarType ty) <$> desugarExpr expr) rows
+desugarExpr (T.ERecordSelect expr (Located _ label) ty) = do
   expr' <- desugarExpr expr
   let ty' = desugarType ty
   pure $ C.ERecordSelect expr' label ty'
-desugarExpr (T.EVar ident) = pure $ C.EVar $ desugarTypedIdent ident
-desugarExpr (T.ECon (Typed ty con)) = pure $ C.ECon $ Typed (desugarType ty) con
-desugarExpr (T.ECase (T.Case scrutinee matches)) = do
+desugarExpr (T.EVar ident) = pure $ C.EVar $ desugarTypedIdent $ locatedValue <$> ident
+desugarExpr (T.ECon (Typed ty (Located _ con))) = pure $ C.ECon $ Typed (desugarType ty) con
+desugarExpr (T.ECase (T.Case scrutinee matches _x)) = do
   -- Desugar the case expression
   scrutinee' <- desugarExpr scrutinee
   let scrutineeTy = desugarType $ T.expressionType scrutinee
@@ -79,22 +82,23 @@ desugarExpr (T.ECase (T.Case scrutinee matches)) = do
             , C.bindingBody = scrutinee'
             }
         in C.ELet $ C.Let (scrutineeBinding :| []) e
-desugarExpr (T.ELam (T.Lambda args body ty)) = do
-  let args' = desugarTypedIdent <$> args
+desugarExpr (T.ELam (T.Lambda args body _ ty)) = do
+  let args' = desugarTypedIdent . fmap locatedValue <$> args
   body' <- desugarExpr body
   let ty' = desugarType ty
   pure $ C.ELam $ C.Lambda args' body' ty'
-desugarExpr (T.EIf (T.If pred' then' else')) =
+desugarExpr (T.EIf (T.If pred' then' else' _)) =
   let
     boolTyCon' = TyCon (notLocated boolTyCon)
-    mkBoolPatCons cons = T.PatCons cons Nothing boolTyCon'
+    loc = mkSourceSpan "<generated>" 1 1 1 1
+    mkBoolPatCons cons = T.PatCons (Located loc cons) Nothing boolTyCon'
     matches =
       NE.fromList
       [ T.Match (T.PCons $ mkBoolPatCons trueDataCon) then'
       , T.Match (T.PCons $ mkBoolPatCons falseDataCon) else'
       ]
-  in desugarExpr (T.ECase (T.Case pred' matches))
-desugarExpr (T.ELet (T.Let bindings body)) = do
+  in desugarExpr (T.ECase (T.Case pred' matches loc))
+desugarExpr (T.ELet (T.Let bindings body _)) = do
   bindings' <- traverse (traverse desugarBinding) bindings
   body' <- desugarExpr body
   -- N.B. Core only allows on binding group per let expression.
@@ -128,9 +132,9 @@ matchToEquation (T.Match pat body) = do
   pure ([pat'], body')
 
 convertPattern :: T.Pattern -> Desugar PC.InputPattern
-convertPattern (T.PLit lit) = pure $ PC.PCon (PC.ConLit lit) []
-convertPattern (T.PVar ident) = pure $ PC.PVar $ desugarTypedIdent ident
-convertPattern (T.PCons (T.PatCons con mArg _)) = do
+convertPattern (T.PLit (Located _ lit)) = pure $ PC.PCon (PC.ConLit lit) []
+convertPattern (T.PVar ident) = pure $ PC.PVar $ desugarTypedIdent (locatedValue <$> ident)
+convertPattern (T.PCons (T.PatCons (Located _ con) mArg _)) = do
   (tyDecl, _) <- lookupDataConType con
   argPats <- traverse convertPattern $ maybeToList mArg
   let

--- a/library/Amy/Core/LambdaLift.hs
+++ b/library/Amy/Core/LambdaLift.hs
@@ -255,7 +255,7 @@ makeLiftedAppNode lifted@(LiftedBinding newArgs binding) =
 maybeEtaExpandExpr :: Expr -> [Expr] -> Maybe Type -> Lift Expr
 maybeEtaExpandExpr expr@(EVar (Typed _ func)) args mRetTy =
   etaExpand expr args mRetTy
-  . maybe [] (fmap TyCon . drop (length args) . NE.init . primitiveFunctionType)
+  . maybe [] (fmap (TyCon . notLocated) . drop (length args) . NE.init . primitiveFunctionType)
   $ Map.lookup func primitiveFunctionsByName
 maybeEtaExpandExpr expr@(ECon (Typed ty _)) args mRetTy = do
   let

--- a/library/Amy/Core/Monad.hs
+++ b/library/Amy/Core/Monad.hs
@@ -24,7 +24,7 @@ newtype Desugar a = Desugar (ReaderT (Map DataConName (TypeDeclaration, DataConD
 runDesugar :: [TypeDeclaration] -> Desugar a -> a
 runDesugar decls (Desugar action) = evalState (runReaderT action dataConMap) 0
  where
-  allTypeDecls = decls ++ (fromPrimTypeDefinition <$> allPrimTypeDefinitions)
+  allTypeDecls = decls ++ allPrimTypeDefinitions
   dataConMap = Map.fromList $ concatMap mkDataConTypes allTypeDecls
 
 freshId :: Desugar Int
@@ -42,7 +42,7 @@ freshIdent t = do
 mkDataConTypes :: TypeDeclaration -> [(DataConName, (TypeDeclaration, DataConDefinition))]
 mkDataConTypes tyDecl@(TypeDeclaration _ dataConDefs) = mkDataConPair <$> dataConDefs
  where
-  mkDataConPair def@(DataConDefinition name _) = (name, (tyDecl, def))
+  mkDataConPair def@(DataConDefinition (Located _ name) _) = (name, (tyDecl, def))
 
 lookupDataConType :: DataConName -> Desugar (TypeDeclaration, DataConDefinition)
 lookupDataConType con =

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -15,10 +15,12 @@ import Amy.Pretty
 prettyType :: Type -> Doc ann
 prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
 prettyType (TyCon con) = prettyTyConName con
+prettyType (TyExistVar _) = error "Found TyExistVar in Core"
 prettyType (TyVar var) = prettyTyVarName var
 prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
 prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
 prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
+prettyType (LocatedType _ _) = error "Found LocatedType in Core"
 
 prettyTyRow :: RowLabel -> Type -> Doc ann
 prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -12,28 +12,6 @@ import Amy.Core.AST
 import Amy.Literal
 import Amy.Pretty
 
-prettyType :: Type -> Doc ann
-prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
-prettyType (TyCon con) = prettyTyConName con
-prettyType (TyExistVar _) = error "Found TyExistVar in Core"
-prettyType (TyVar var) = prettyTyVarName var
-prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
-prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
-prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
-prettyType (LocatedType _ _) = error "Found LocatedType in Core"
-
-prettyTyRow :: RowLabel -> Type -> Doc ann
-prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty
-
-isTyApp :: Type -> Bool
-isTyApp TyApp{} = True
-isTyApp TyFun{} = True
-isTyApp _ = False
-
-isTyFun :: Type -> Bool
-isTyFun TyFun{} = True
-isTyFun _ = False
-
 prettyModule :: Module -> Doc ann
 prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines

--- a/library/Amy/Core/Pretty.hs
+++ b/library/Amy/Core/Pretty.hs
@@ -49,13 +49,13 @@ prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
    prettyTypeDeclaration (prettyTyConDefinition tyName) (prettyConstructor <$> cons)
  where
-  prettyConstructor (DataConDefinition conName mArg) =
+  prettyConstructor (DataConDefinition (Located _ conName) mArg) =
     prettyDataConstructor (prettyDataConName conName) (prettyType <$> mArg)
 
 prettyTyConDefinition :: TyConDefinition -> Doc ann
-prettyTyConDefinition (TyConDefinition name args) = prettyTyConName name <> args'
+prettyTyConDefinition (TyConDefinition (Located _ name) args) = prettyTyConName name <> args'
  where
-  args' = if null args then mempty else space <> sep (prettyTyVarName <$> args)
+  args' = if null args then mempty else space <> sep (prettyTyVarName . locatedValue <$> args)
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding ident ty args _ body) =

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -10,6 +10,7 @@ module Amy.Errors
   ) where
 
 import Data.Text.Prettyprint.Doc.Render.String (renderString)
+import Text.Megaparsec.Pos
 
 import Amy.Kind
 import Amy.Pretty
@@ -22,9 +23,9 @@ data Error
   } deriving (Show, Eq)
 
 showError :: Error -> String
-showError (Error message (SourceSpan fileName lineNo col _ _)) =
+showError (Error message (SourceSpan start _)) =
   renderString . layoutPretty defaultLayoutOptions $
-    pretty fileName <> ":" <> pretty lineNo <> ":" <> pretty col <> ":" <> groupOrHang (prettyErrorMessage message)
+    pretty (sourcePosPretty start) <> ":" <> groupOrHang (prettyErrorMessage message)
 
 data ErrorMessage
   = UnknownVariable !IdentName

--- a/library/Amy/Errors.hs
+++ b/library/Amy/Errors.hs
@@ -14,8 +14,6 @@ import Data.Text.Prettyprint.Doc.Render.String (renderString)
 import Amy.Kind
 import Amy.Pretty
 import Amy.Syntax.AST as S
-import Amy.TypeCheck.AST as T
-import Amy.TypeCheck.Pretty as T
 
 data Error
   = Error
@@ -36,9 +34,9 @@ data ErrorMessage
   | VariableShadowed !IdentName
   | DuplicateDataConstructor !DataConName
   | DuplicateTypeConstructor !TyConName
-  | UnificationFail !T.Type !T.Type
+  | UnificationFail !Type !Type
   | KindUnificationFail !Kind ! Kind
-  | InfiniteType !TyExistVarName !T.Type
+  | InfiniteType !TyExistVarName !Type
   | InfiniteKind !Int !Kind
   | TooManyBindingArguments !Int !Int
   deriving (Show, Eq)
@@ -53,10 +51,10 @@ prettyErrorMessage = \case
   DuplicateDataConstructor con -> "Data constructor already exists:" <+> prettyDataConName con
   DuplicateTypeConstructor con -> "Type constructor already exists:" <+> prettyTyConName con
   UnificationFail t1 t2 ->
-    "Could not match type" <> hardline <> indent 2 (T.prettyType t1) <> hardline <> "with type" <> hardline <> indent 2 (T.prettyType t2)
+    "Could not match type" <> hardline <> indent 2 (prettyType t1) <> hardline <> "with type" <> hardline <> indent 2 (prettyType t2)
   KindUnificationFail k1 k2 ->
     "Could not match kind" <> hardline <> indent 2 (prettyKind k1) <> hardline <> "with kind" <> hardline <> indent 2 (prettyKind k2)
-  InfiniteType _ t -> "Cannot infer infinite type:" <> T.prettyType t
+  InfiniteType _ t -> "Cannot infer infinite type:" <> prettyType t
   InfiniteKind _ k -> "Cannot infer infinite kind:" <> prettyKind k
   TooManyBindingArguments expected actual ->
     "Too many arguments to binding. Declared type implies a maximum of" <+> pretty expected <+>

--- a/library/Amy/Pretty.hs
+++ b/library/Amy/Pretty.hs
@@ -48,6 +48,7 @@ import qualified Data.Map.Strict as Map
 
 import Amy.Kind
 import Amy.Names
+import Amy.Syntax.Located
 import Amy.Type
 
 --
@@ -136,16 +137,14 @@ isKFun _ = False
 
 prettyType :: Type -> Doc ann
 prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
-prettyType (TyCon con) = prettyTyConName con
+prettyType (TyCon (MaybeLocated _ con)) = prettyTyConName con
 prettyType (TyExistVar var) = prettyTyExistVarName var
-prettyType (TyVar var) = prettyTyVarName var
+prettyType (TyVar (MaybeLocated _ var)) = prettyTyVarName var
 prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
+ where
+  prettyTyRow (MaybeLocated _ label) ty = prettyRowLabel label <+> "::" <+> prettyType ty
 prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
-prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
-prettyType (LocatedType _ ty) = prettyType ty
-
-prettyTyRow :: RowLabel -> Type -> Doc ann
-prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty
+prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName . maybeLocatedValue <$> toList vars) <> "." <+> prettyType ty
 
 isTyApp :: Type -> Bool
 isTyApp TyApp{} = True

--- a/library/Amy/Prim.hs
+++ b/library/Amy/Prim.hs
@@ -96,10 +96,13 @@ allPrimTypeDefinitions =
   , boolTypeDefinition
   ]
 
-literalType :: Literal -> TyConName
-literalType (LiteralInt _) = intTyCon
-literalType (LiteralDouble _) = doubleTyCon
-literalType (LiteralText _) = textTyCon
+literalType :: Literal -> Type
+literalType = TyCon . notLocated . literalTyCon
+
+literalTyCon :: Literal -> TyConName
+literalTyCon (LiteralInt _) = intTyCon
+literalTyCon (LiteralDouble _) = doubleTyCon
+literalTyCon (LiteralText _) = textTyCon
 
 --
 -- Primitive Functions

--- a/library/Amy/Prim.hs
+++ b/library/Amy/Prim.hs
@@ -35,6 +35,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import Text.Megaparsec.Pos
 
 import Amy.Literal
 import Amy.Names
@@ -47,7 +48,8 @@ import Amy.Syntax.AST
 mkPrimTypeDef :: TyConName -> [DataConName] -> TypeDeclaration
 mkPrimTypeDef tyConName dataConNames =
   let
-    span' = SourceSpan "<prim>" 1 1 1 1
+    pos = SourcePos "<prim>" (mkPos 1) (mkPos 1)
+    span' = SourceSpan pos pos
     tyConDef = TyConDefinition (Located span' tyConName) []
     mkDataConDef con = DataConDefinition (Located span' con) Nothing
     dataCons = mkDataConDef <$> dataConNames

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -217,12 +217,13 @@ patternSpan (PCons (PatCons (Located s _) mPat)) =
 patternSpan (PParens pat) = patternSpan pat
 
 data Type
-  = TyCon !(Located TyConName)
-  | TyVar !(Located TyVarName)
+  = TyCon !TyConName
+  | TyVar !TyVarName
   | TyApp !Type !Type
-  | TyRecord !(Map (Located RowLabel) Type) !(Maybe (Located TyVarName))
+  | TyRecord !(Map RowLabel Type) !(Maybe TyVarName)
   | TyFun !Type !Type
-  | TyForall !(NonEmpty (Located TyVarName)) !Type
+  | TyForall !(NonEmpty TyVarName) !Type
+  | LocatedType !SourceSpan !Type
   deriving (Show, Eq)
 
 infixr 0 `TyFun`

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -10,9 +10,6 @@ module Amy.Syntax.AST
   , Binding(..)
   , BindingType(..)
   , Extern(..)
-  , TypeDeclaration(..)
-  , TyConDefinition(..)
-  , DataConDefinition(..)
   , Expr(..)
   , If(..)
   , Case(..)
@@ -97,24 +94,6 @@ data Extern
   = Extern
   { externName :: !(Located IdentName)
   , externType :: !Type
-  } deriving (Show, Eq)
-
-data TypeDeclaration
-  = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConDefinition
-  , typeDeclarationConstructors :: ![DataConDefinition]
-  } deriving (Show, Eq)
-
-data TyConDefinition
-  = TyConDefinition
-  { tyConDefinitionName :: !(Located TyConName)
-  , tyConDefinitionArgs :: ![Located TyVarName]
-  } deriving (Show, Eq)
-
-data DataConDefinition
-  = DataConDefinition
-  { dataConDefinitionName :: !(Located DataConName)
-  , dataConDefinitionArgument :: !(Maybe Type)
   } deriving (Show, Eq)
 
 data Expr

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -27,9 +27,8 @@ module Amy.Syntax.AST
 
     -- Re-export
   , Literal(..)
-  , Located(..)
-  , SourceSpan(..)
   , module Amy.Names
+  , module Amy.Syntax.Located
   , module Amy.Type
   ) where
 

--- a/library/Amy/Syntax/AST.hs
+++ b/library/Amy/Syntax/AST.hs
@@ -27,13 +27,13 @@ module Amy.Syntax.AST
   , matchSpan
   , patternSpan
   , LetBinding(..)
-  , Type(..)
 
     -- Re-export
   , Literal(..)
   , Located(..)
   , SourceSpan(..)
   , module Amy.Names
+  , module Amy.Type
   ) where
 
 import Data.List.NonEmpty (NonEmpty)
@@ -42,6 +42,7 @@ import Data.Map.Strict (Map)
 import Amy.Literal (Literal(..))
 import Amy.Names
 import Amy.Syntax.Located
+import Amy.Type
 
 -- | A 'Module' is simply a list of 'Declaration' values.
 data Module
@@ -215,15 +216,3 @@ patternSpan (PCons (PatCons (Located s _) mPat)) =
     Nothing -> s
     Just pat -> mergeSpans s (patternSpan pat)
 patternSpan (PParens pat) = patternSpan pat
-
-data Type
-  = TyCon !TyConName
-  | TyVar !TyVarName
-  | TyApp !Type !Type
-  | TyRecord !(Map RowLabel Type) !(Maybe TyVarName)
-  | TyFun !Type !Type
-  | TyForall !(NonEmpty TyVarName) !Type
-  | LocatedType !SourceSpan !Type
-  deriving (Show, Eq)
-
-infixr 0 `TyFun`

--- a/library/Amy/Syntax/Located.hs
+++ b/library/Amy/Syntax/Located.hs
@@ -4,6 +4,9 @@
 
 module Amy.Syntax.Located
   ( Located(..)
+  , MaybeLocated(..)
+  , fromLocated
+  , notLocated
   , SourceSpan(..)
   , mergeSpans
   , mkSourcePos
@@ -18,6 +21,19 @@ data Located a
   { locatedSpan :: !SourceSpan
   , locatedValue :: !a
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+
+-- | Possible location of something in source code.
+data MaybeLocated a
+  = MaybeLocated
+  { maybeLocatedSpan :: !(Maybe SourceSpan)
+  , maybeLocatedValue :: !a
+  } deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+
+fromLocated :: Located a -> MaybeLocated a
+fromLocated (Located span' x) = MaybeLocated (Just span') x
+
+notLocated :: a -> MaybeLocated a
+notLocated = MaybeLocated Nothing
 
 -- | A file path along with a start and end 'SourcePos'.
 data SourceSpan

--- a/library/Amy/Syntax/Located.hs
+++ b/library/Amy/Syntax/Located.hs
@@ -10,6 +10,7 @@ module Amy.Syntax.Located
   , SourceSpan(..)
   , mergeSpans
   , mkSourcePos
+  , mkSourceSpan
   , module Text.Megaparsec.Pos
   ) where
 
@@ -47,3 +48,6 @@ mergeSpans (SourceSpan start _) (SourceSpan _ end) = SourceSpan start end
 
 mkSourcePos :: FilePath -> Int -> Int -> SourcePos
 mkSourcePos fp line col = SourcePos fp (mkPos line) (mkPos col)
+
+mkSourceSpan :: FilePath -> Int -> Int -> Int -> Int -> SourceSpan
+mkSourceSpan fp startLine startCol endLine endCol = SourceSpan (mkSourcePos fp startLine startCol) (mkSourcePos fp endLine endCol)

--- a/library/Amy/Syntax/Located.hs
+++ b/library/Amy/Syntax/Located.hs
@@ -6,7 +6,11 @@ module Amy.Syntax.Located
   ( Located(..)
   , SourceSpan(..)
   , mergeSpans
+  , mkSourcePos
+  , module Text.Megaparsec.Pos
   ) where
+
+import Text.Megaparsec.Pos
 
 -- | Location of something in source code.
 data Located a
@@ -18,13 +22,12 @@ data Located a
 -- | A file path along with a start and end 'SourcePos'.
 data SourceSpan
   = SourceSpan
-  { sourceSpanFile :: !FilePath
-  , sourceSpanStartLine :: !Int
-  , sourceSpanStartColumn :: !Int
-  , sourceSpanEndLine :: !Int
-  , sourceSpanEndColumn :: !Int
+  { sourceSpanStart :: !SourcePos
+  , sourceSpanEnd :: !SourcePos
   } deriving (Show, Eq, Ord)
 
 mergeSpans :: SourceSpan -> SourceSpan -> SourceSpan
-mergeSpans (SourceSpan file startLine startCol _ _) (SourceSpan _ _ _ endLine endCol) =
-  SourceSpan file startLine startCol endLine endCol
+mergeSpans (SourceSpan start _) (SourceSpan _ end) = SourceSpan start end
+
+mkSourcePos :: FilePath -> Int -> Int -> SourcePos
+mkSourcePos fp line col = SourcePos fp (mkPos line) (mkPos col)

--- a/library/Amy/Syntax/Parser.hs
+++ b/library/Amy/Syntax/Parser.hs
@@ -104,7 +104,7 @@ tyCon' = do
   (Located span' con) <- tyCon
   pure $ LocatedType span' (TyCon con)
 
-tyRecord :: AmyParser (Map RowLabel Type, Maybe TyVarName)
+tyRecord :: AmyParser (Map RowLabel Type, Maybe Type)
 tyRecord =
   between lBrace rBrace $ do
     fields <- (`sepBy` comma) $ do
@@ -112,7 +112,7 @@ tyRecord =
       _ <- assertIndented *> doubleColon
       ty <- parseType
       pure (label', ty)
-    mTyVar <- optional . fmap locatedValue $ assertIndented *> pipe *> assertIndented *> tyVar
+    mTyVar <- optional $ assertIndented *> pipe *> assertIndented *> parseType
     pure (Map.fromList fields, mTyVar)
 
 binding :: AmyParser Binding

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -17,14 +17,15 @@ import Amy.Syntax.AST
 
 prettyType :: Type -> Doc ann
 prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
-prettyType (TyCon con) = prettyTyConName (locatedValue con)
-prettyType (TyVar var) = prettyTyVarName (locatedValue var)
-prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyTyVarName . locatedValue <$> mVar)
+prettyType (TyCon con) = prettyTyConName con
+prettyType (TyVar var) = prettyTyVarName var
+prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyTyVarName <$> mVar)
 prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
-prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName . locatedValue <$> toList vars) <> "." <+> prettyType ty
+prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
+prettyType (LocatedType _ ty) = prettyType ty
 
-prettyTyRow :: Located RowLabel -> Type -> Doc ann
-prettyTyRow (Located _ label) ty = prettyRowLabel label <+> "::" <+> prettyType ty
+prettyTyRow :: RowLabel -> Type -> Doc ann
+prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty
 
 isTyApp :: Type -> Bool
 isTyApp TyApp{} = True

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -18,8 +18,9 @@ import Amy.Syntax.AST
 prettyType :: Type -> Doc ann
 prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
 prettyType (TyCon con) = prettyTyConName con
+prettyType (TyExistVar _) = error "Found TyExistVar in Syntax AST"
 prettyType (TyVar var) = prettyTyVarName var
-prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyTyVarName <$> mVar)
+prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
 prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
 prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
 prettyType (LocatedType _ ty) = prettyType ty

--- a/library/Amy/Syntax/Pretty.hs
+++ b/library/Amy/Syntax/Pretty.hs
@@ -15,28 +15,6 @@ import Amy.Literal
 import Amy.Pretty
 import Amy.Syntax.AST
 
-prettyType :: Type -> Doc ann
-prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
-prettyType (TyCon con) = prettyTyConName con
-prettyType (TyExistVar _) = error "Found TyExistVar in Syntax AST"
-prettyType (TyVar var) = prettyTyVarName var
-prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
-prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
-prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
-prettyType (LocatedType _ ty) = prettyType ty
-
-prettyTyRow :: RowLabel -> Type -> Doc ann
-prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty
-
-isTyApp :: Type -> Bool
-isTyApp TyApp{} = True
-isTyApp TyFun{} = True -- Technically -> is an infix app
-isTyApp _ = False
-
-isTyFun :: Type -> Bool
-isTyFun TyFun{} = True
-isTyFun _ = False
-
 prettyModule :: Module -> Doc ann
 prettyModule (Module _ decls) = vcatTwoHardLines (prettyDeclaration <$> decls)
 

--- a/library/Amy/Type.hs
+++ b/library/Amy/Type.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Amy.Type
   ( Type(..)
   , Typed(..)
   , unfoldTyApp
   , unfoldTyFun
+  , traverseType
+  , traverseTypeM
+  , removeLocatedType
+  , removeTyExistVar
   ) where
 
+import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
+import Data.Text (pack)
 
 import Amy.Names
 import Amy.Syntax.Located
@@ -42,3 +49,40 @@ unfoldTyFun :: Type -> NonEmpty Type
 unfoldTyFun (TyForall _ t) = unfoldTyFun t
 unfoldTyFun (t1 `TyFun` t2) = NE.cons t1 (unfoldTyFun t2)
 unfoldTyFun ty = ty :| []
+
+traverseType :: (Type -> Type) -> Type -> Type
+traverseType f = runIdentity . traverseTypeM (Identity . f)
+
+-- | Single step of a traversal through a 'Type'.
+--
+-- This function doesn't traverse the entire 'Type'. It applies a function to
+-- all the immediate sub nodes of a single node. This is most useful when
+-- paired with another mutually recursive function (@f@) that singles out the
+-- nodes it cares about, and leaves this function to traverse the ones it
+-- doesn't.
+--
+traverseTypeM :: (Monad m) => (Type -> m Type) -> Type -> m Type
+traverseTypeM f = go
+ where
+  go t@TyCon{} = pure t
+  go t@TyVar{} = pure t
+  go t@TyExistVar{} = pure t
+  go (TyApp t1 t2) = TyApp <$> f t1 <*> f t2
+  go (TyRecord rows mTail) = TyRecord <$> traverse f rows <*> traverse f mTail
+  go (TyFun t1 t2) = TyFun <$> f t1 <*> f t2
+  go (TyForall vars ty) = TyForall vars <$> f ty
+  go (LocatedType ss ty) = LocatedType ss <$> f ty
+
+-- | Remove any 'LocatedType' nodes from a 'Type'.
+removeLocatedType :: Type -> Type
+removeLocatedType = go
+ where
+  go (LocatedType _ ty) = ty
+  go t = traverseType go t
+
+-- | Replace any 'TyExistVar' nodes with 'TyVar' nodes.
+removeTyExistVar :: Type -> Type
+removeTyExistVar = go
+ where
+  go (TyExistVar (TyExistVarName i)) = TyVar $ TyVarName $ "$t" <> pack (show i)
+  go t = traverseType go t

--- a/library/Amy/Type.hs
+++ b/library/Amy/Type.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Amy.Type
+  ( Type(..)
+  , Typed(..)
+  , unfoldTyApp
+  , unfoldTyFun
+  ) where
+
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
+import Data.Map.Strict (Map)
+
+import Amy.Names
+import Amy.Syntax.Located
+
+data Type
+  = TyCon !TyConName
+  | TyVar !TyVarName
+  | TyExistVar !TyExistVarName
+  | TyApp !Type !Type
+  | TyRecord !(Map RowLabel Type) !(Maybe Type)
+  | TyFun !Type !Type
+  | TyForall !(NonEmpty TyVarName) !Type
+  | LocatedType !SourceSpan !Type
+  deriving (Show, Eq, Ord)
+
+infixr 0 `TyFun`
+
+data Typed a
+  = Typed
+  { typedType :: !Type
+  , typedValue :: !a
+  } deriving (Show, Eq, Ord, Functor)
+
+unfoldTyApp :: Type -> NonEmpty Type
+unfoldTyApp (TyApp app@(TyApp _ _) arg) = unfoldTyApp app <> (arg :| [])
+unfoldTyApp (TyApp f arg) = f :| [arg]
+unfoldTyApp t = t :| []
+
+unfoldTyFun :: Type -> NonEmpty Type
+unfoldTyFun (TyForall _ t) = unfoldTyFun t
+unfoldTyFun (t1 `TyFun` t2) = NE.cons t1 (unfoldTyFun t2)
+unfoldTyFun ty = ty :| []

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 module Amy.TypeCheck.AST
   ( Module(..)
   , Binding(..)
@@ -20,24 +18,21 @@ module Amy.TypeCheck.AST
   , matchType
   , patternType
 
-  , Type(..)
-  , unfoldTyFun
-  , Typed(..)
-
     -- Re-export
   , Literal(..)
   , module Amy.ASTCommon
   , module Amy.Names
+  , module Amy.Type
   ) where
 
 import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 
 import Amy.ASTCommon
 import Amy.Literal
 import Amy.Names
 import Amy.Prim
+import Amy.Type
 
 data Module
   = Module
@@ -177,25 +172,3 @@ patternType (PLit lit) = literalType' lit
 patternType (PVar (Typed ty _)) = ty
 patternType (PCons (PatCons _ _ ty)) = ty
 patternType (PParens pat) = patternType pat
-
-data Type
-  = TyCon !TyConName
-  | TyVar !TyVarName
-  | TyExistVar !TyExistVarName
-  | TyApp !Type !Type
-  | TyRecord !(Map RowLabel Type) !(Maybe Type)
-  | TyFun !Type !Type
-  | TyForall !(NonEmpty TyVarName) !Type
-  deriving (Show, Eq, Ord)
-
-infixr 0 `TyFun`
-
-unfoldTyFun :: Type -> NonEmpty Type
-unfoldTyFun (t1 `TyFun` t2) = NE.cons t1 (unfoldTyFun t2)
-unfoldTyFun ty = ty :| []
-
-data Typed a
-  = Typed
-  { typedType :: !Type
-  , typedValue :: !a
-  } deriving (Show, Eq, Ord, Functor)

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -17,14 +17,15 @@ module Amy.TypeCheck.AST
 
     -- Re-export
   , Literal(..)
-  , Located(..)
   , module Amy.ASTCommon
   , module Amy.Names
+  , module Amy.Syntax.Located
   , module Amy.Type
   ) where
 
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import Amy.ASTCommon
 import Amy.Literal
@@ -129,12 +130,9 @@ data App
   , appReturnType :: !Type
   } deriving (Show, Eq)
 
-literalType' :: Literal -> Type
-literalType' lit = TyCon $ literalType lit
-
 expressionType :: Expr -> Type
-expressionType (ELit lit) = literalType' lit
-expressionType (ERecord rows) = TyRecord (typedType <$> rows) Nothing
+expressionType (ELit lit) = literalType lit
+expressionType (ERecord rows) = TyRecord (Map.mapKeys notLocated $ typedType <$> rows) Nothing
 expressionType (ERecordSelect _ _ ty) = ty
 expressionType (EVar (Typed ty _)) = ty
 expressionType (ECon (Typed ty _)) = ty
@@ -149,7 +147,7 @@ matchType :: Match -> Type
 matchType (Match _ expr) = expressionType expr
 
 patternType :: Pattern -> Type
-patternType (PLit lit) = literalType' lit
+patternType (PLit lit) = literalType lit
 patternType (PVar (Typed ty _)) = ty
 patternType (PCons (PatCons _ _ ty)) = ty
 patternType (PParens pat) = patternType pat

--- a/library/Amy/TypeCheck/AST.hs
+++ b/library/Amy/TypeCheck/AST.hs
@@ -2,9 +2,6 @@ module Amy.TypeCheck.AST
   ( Module(..)
   , Binding(..)
   , Extern(..)
-  , TypeDeclaration(..)
-  , TyConDefinition(..)
-  , DataConDefinition(..)
   , Expr(..)
   , If(..)
   , Case(..)
@@ -20,6 +17,7 @@ module Amy.TypeCheck.AST
 
     -- Re-export
   , Literal(..)
+  , Located(..)
   , module Amy.ASTCommon
   , module Amy.Names
   , module Amy.Type
@@ -32,6 +30,7 @@ import Amy.ASTCommon
 import Amy.Literal
 import Amy.Names
 import Amy.Prim
+import Amy.Syntax.Located
 import Amy.Type
 
 data Module
@@ -61,24 +60,6 @@ data Extern
   { externName :: !IdentName
   , externType :: !Type
   } deriving (Show, Eq)
-
-data TypeDeclaration
-  = TypeDeclaration
-  { typeDeclarationTypeName :: !TyConDefinition
-  , typeDeclarationConstructors :: ![DataConDefinition]
-  } deriving (Show, Eq, Ord)
-
-data TyConDefinition
-  = TyConDefinition
-  { tyConDefinitionName :: !TyConName
-  , tyConDefinitionArgs :: ![TyVarName]
-  } deriving (Show, Eq, Ord)
-
-data DataConDefinition
-  = DataConDefinition
-  { dataConDefinitionName :: !DataConName
-  , dataConDefinitionArgument :: !(Maybe Type)
-  } deriving (Show, Eq, Ord)
 
 -- | A renamed 'Expr'
 data Expr

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -95,6 +95,7 @@ inferTypeKind' (TyRecord fields mTail) = do
 inferTypeKind' (TyForall vars ty) = withNewLexicalScope $ do
   traverse_ addUnknownTyVarKindToScope vars
   inferTypeKind' ty
+inferTypeKind' (LocatedType _ ty) = inferTypeKind' ty
 inferTypeKind' v@(TyExistVar _) = error $ "Found existential variable in kind inference " ++ show v
 
 -- | If we have any unknown kinds left, just call them KStar.

--- a/library/Amy/TypeCheck/KindInference.hs
+++ b/library/Amy/TypeCheck/KindInference.hs
@@ -28,12 +28,12 @@ import Amy.TypeCheck.Monad
 -- same time instead of one by one.
 
 inferTypeDeclarationKind :: TypeDeclaration -> Checker Kind
-inferTypeDeclarationKind (TypeDeclaration (TyConDefinition tyCon tyArgs) constructors) =
+inferTypeDeclarationKind (TypeDeclaration (TyConDefinition (Located _ tyCon) tyArgs) constructors) =
   withNewLexicalScope $ do
     -- Generate unknown kind variables for the type constructor and all type
     -- variables.
     tyConKindVar <- addUnknownTyConKindToScope tyCon
-    tyVarKindVars <- traverse addUnknownTyVarKindToScope tyArgs
+    tyVarKindVars <- traverse (addUnknownTyVarKindToScope . locatedValue) tyArgs
     let
       tyConConstraint = Constraint (KUnknown tyConKindVar, foldr1 KFun $ (KUnknown <$> tyVarKindVars) ++ [KStar])
 

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -174,6 +174,7 @@ runChecker identTypes dataConTypes moduleFile (Checker action) = do
  where
   dataConNames = fst <$> dataConTypes
   groupedConNames = NE.groupAllWith locatedValue . sort $ dataConNames
+  pos = SourcePos moduleFile pos1 pos1
   checkState =
     CheckState
     { latestId = 0
@@ -182,7 +183,7 @@ runChecker identTypes dataConTypes moduleFile (Checker action) = do
     , dataConstructorTypes = Map.fromList (first locatedValue <$> dataConTypes)
     , tyVarKinds = Map.empty
     , tyConKinds = Map.empty
-    , sourceSpan = SourceSpan moduleFile 1 1 1 1
+    , sourceSpan = SourceSpan pos pos
     }
 
 freshId :: Checker Int

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -57,7 +57,6 @@ import qualified Data.Sequence as Seq
 import Amy.TypeCheck.AST
 import Amy.Errors
 import Amy.Kind
-import Amy.Syntax.Located
 
 --
 -- Context
@@ -122,7 +121,7 @@ contextUntil member (Context context) = Context $ Seq.takeWhileL (/= member) con
 
 typeWellFormed :: Context -> Type -> Maybe ErrorMessage
 typeWellFormed _ (TyCon _) = Nothing
-typeWellFormed context (TyVar v) = do
+typeWellFormed context (TyVar (MaybeLocated _ v)) = do
   guard $ not $ ContextVar v `contextElem` context
   Just $ UnknownTypeVariable v
 typeWellFormed context (TyExistVar v) = do
@@ -134,8 +133,7 @@ typeWellFormed context (TyExistVar v) = do
 typeWellFormed context (TyApp x y) = typeWellFormed context x >> typeWellFormed context y
 typeWellFormed context (TyFun x y) = typeWellFormed context x >> typeWellFormed context y
 typeWellFormed context (TyRecord rows mTy) = asum (typeWellFormed context <$> rows) >> (mTy >>= typeWellFormed context)
-typeWellFormed context (TyForall vs t) = typeWellFormed (context <> Context (Seq.fromList $ NE.toList $ ContextVar <$> vs)) t
-typeWellFormed context (LocatedType _ t) = typeWellFormed context t
+typeWellFormed context (TyForall vs t) = typeWellFormed (context <> Context (Seq.fromList $ NE.toList $ ContextVar . maybeLocatedValue <$> vs)) t
 
 --
 -- Monad

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -99,6 +99,7 @@ contextSubst ctx record@(TyRecord rows mTail) =
     Just t -> TyRecord rows' (Just t)
 contextSubst ctx (TyFun a b) = TyFun (contextSubst ctx a) (contextSubst ctx b)
 contextSubst ctx (TyForall vs t) = TyForall vs (contextSubst ctx t)
+contextSubst ctx (LocatedType ss t) = LocatedType ss $ contextSubst ctx t
 
 -- | Γ = Γ0[Θ] means Γ has the form (ΓL, Θ,ΓR)
 contextHole :: ContextMember -> Context -> Maybe (Context, Context)
@@ -137,6 +138,7 @@ typeWellFormed context (TyApp x y) = typeWellFormed context x >> typeWellFormed 
 typeWellFormed context (TyFun x y) = typeWellFormed context x >> typeWellFormed context y
 typeWellFormed context (TyRecord rows mTy) = asum (typeWellFormed context <$> rows) >> (mTy >>= typeWellFormed context)
 typeWellFormed context (TyForall vs t) = typeWellFormed (context <> Context (Seq.fromList $ NE.toList $ ContextVar <$> vs)) t
+typeWellFormed context (LocatedType _ t) = typeWellFormed context t
 
 --
 -- Monad

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -22,6 +22,7 @@ prettyType (TyExistVar var) = prettyTyExistVarName var
 prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
 prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
 prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
+prettyType (LocatedType _ ty) = prettyType ty
 
 prettyTyRow :: RowLabel -> Type -> Doc ann
 prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -22,7 +22,7 @@ prettyModule (Module bindings externs typeDeclarations) =
   ++ (prettyBinding' <$> concat (toList <$> bindings))
 
 prettyExtern' :: Extern -> Doc ann
-prettyExtern' (Extern name ty) =
+prettyExtern' (Extern (Located _ name) ty) =
   prettyExtern (prettyIdent name) (prettyType ty)
 
 prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
@@ -38,29 +38,30 @@ prettyTyConDefinition (TyConDefinition (Located _ name) args) = prettyTyConName 
   args' = if null args then mempty else space <> sep (prettyTyVarName . locatedValue <$> args)
 
 prettyBinding' :: Binding -> Doc ann
-prettyBinding' (Binding ident ty args _ body) =
+prettyBinding' (Binding (Located _ ident) ty args _ body) =
   prettyBindingType' ident ty <>
   hardline <>
-  prettyBinding (prettyIdent ident) (prettyIdent . typedValue <$> args) (prettyExpr body)
+  prettyBinding (prettyIdent ident) (prettyIdent . locatedValue . typedValue <$> args) (prettyExpr body)
 
 prettyBindingType' :: IdentName -> Type -> Doc ann
 prettyBindingType' ident ty = prettyBindingType (prettyIdent ident) (prettyType ty)
 
 prettyExpr :: Expr -> Doc ann
-prettyExpr (ELit lit) = pretty $ showLiteral lit
-prettyExpr (ERecord rows) = bracketed $ uncurry prettyRow <$> Map.toList (typedValue <$> rows)
-prettyExpr (ERecordSelect expr field _) = prettyExpr expr <> "." <> prettyRowLabel field
-prettyExpr (EVar (Typed _ ident)) = prettyIdent ident
-prettyExpr (ECon (Typed _ con)) = prettyDataConName con
-prettyExpr (EIf (If pred' then' else')) =
+prettyExpr (ELit (Located _ lit)) = pretty $ showLiteral lit
+prettyExpr (ERecord rows) = bracketed $ uncurry prettyRow <$> Map.toList (Map.mapKeys locatedValue $ typedValue <$> rows)
+prettyExpr (ERecordSelect expr (Located _ field) _) = prettyExpr expr <> "." <> prettyRowLabel field
+prettyExpr (EVar (Typed _ (Located _ ident))) = prettyIdent ident
+prettyExpr (ECon (Typed _ (Located _ con))) = prettyDataConName con
+prettyExpr (EIf (If pred' then' else' _)) =
   prettyIf (prettyExpr pred') (prettyExpr then') (prettyExpr else')
-prettyExpr (ECase (Case scrutinee matches)) =
+prettyExpr (ECase (Case scrutinee matches _)) =
   prettyCase (prettyExpr scrutinee) Nothing (toList $ mkMatch <$> matches)
  where
   mkMatch (Match pat body) = (prettyPattern pat, prettyExpr body)
-prettyExpr (ELet (Let bindings body)) =
+prettyExpr (ELet (Let bindings body _)) =
   prettyLet (prettyBinding' <$> concat (toList <$> bindings)) (prettyExpr body)
-prettyExpr (ELam (Lambda args body _)) = prettyLambda (prettyIdent . typedValue <$> toList args) (prettyExpr body)
+prettyExpr (ELam (Lambda args body _ _)) =
+  prettyLambda (prettyIdent . locatedValue . typedValue <$> toList args) (prettyExpr body)
 prettyExpr (EApp (App f arg _)) = prettyExpr f <+> prettyExpr arg
 prettyExpr (EParens expr) = parens $ prettyExpr expr
 
@@ -68,10 +69,10 @@ prettyRow :: RowLabel -> Expr -> Doc ann
 prettyRow label expr = prettyRowLabel label <> ":" <+> prettyExpr expr
 
 prettyPattern :: Pattern -> Doc ann
-prettyPattern (PLit lit) = pretty $ showLiteral lit
-prettyPattern (PVar (Typed _ var)) = prettyIdent var
+prettyPattern (PLit (Located _ lit)) = pretty $ showLiteral lit
+prettyPattern (PVar (Typed _ (Located _ var))) = prettyIdent var
 prettyPattern (PParens pat) = parens (prettyPattern pat)
-prettyPattern (PCons (PatCons con mArg _)) =
+prettyPattern (PCons (PatCons (Located _ con) mArg _)) =
   prettyDataConName con <> maybe mempty prettyArg mArg
  where
   prettyArg = (space <>) . prettyArg'

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -51,13 +51,13 @@ prettyTypeDeclaration' :: TypeDeclaration -> Doc ann
 prettyTypeDeclaration' (TypeDeclaration tyName cons) =
    prettyTypeDeclaration (prettyTyConDefinition tyName) (prettyConstructor <$> cons)
  where
-  prettyConstructor (DataConDefinition conName mArg) =
+  prettyConstructor (DataConDefinition (Located _ conName) mArg) =
     prettyDataConstructor (prettyDataConName conName) (prettyType <$> mArg)
 
 prettyTyConDefinition :: TyConDefinition -> Doc ann
-prettyTyConDefinition (TyConDefinition name args) = prettyTyConName name <> args'
+prettyTyConDefinition (TyConDefinition (Located _ name) args) = prettyTyConName name <> args'
  where
-  args' = if null args then mempty else space <> sep (prettyTyVarName <$> args)
+  args' = if null args then mempty else space <> sep (prettyTyVarName . locatedValue <$> args)
 
 prettyBinding' :: Binding -> Doc ann
 prettyBinding' (Binding ident ty args _ body) =

--- a/library/Amy/TypeCheck/Pretty.hs
+++ b/library/Amy/TypeCheck/Pretty.hs
@@ -14,28 +14,6 @@ import Amy.Literal
 import Amy.Pretty
 import Amy.TypeCheck.AST
 
-prettyType :: Type -> Doc ann
-prettyType (TyFun ty1 ty2) = parensIf (isTyFun ty1) (prettyType ty1) <+> "->" <+> prettyType ty2
-prettyType (TyCon con) = prettyTyConName con
-prettyType (TyVar var) = prettyTyVarName var
-prettyType (TyExistVar var) = prettyTyExistVarName var
-prettyType (TyRecord rows mVar) = prettyTyRecord (uncurry prettyTyRow <$> Map.toList rows) (prettyType <$> mVar)
-prettyType (TyApp f arg) = prettyType f <+> parensIf (isTyApp arg) (prettyType arg)
-prettyType (TyForall vars ty) = "forall" <+> hcat (punctuate space $ prettyTyVarName <$> toList vars) <> "." <+> prettyType ty
-prettyType (LocatedType _ ty) = prettyType ty
-
-prettyTyRow :: RowLabel -> Type -> Doc ann
-prettyTyRow label ty = prettyRowLabel label <+> "::" <+> prettyType ty
-
-isTyApp :: Type -> Bool
-isTyApp TyApp{} = True
-isTyApp TyFun{} = True
-isTyApp _ = False
-
-isTyFun :: Type -> Bool
-isTyFun TyFun{} = True
-isTyFun _ = False
-
 prettyModule :: Module -> Doc ann
 prettyModule (Module bindings externs typeDeclarations) =
   vcatTwoHardLines

--- a/library/Amy/TypeCheck/Subtyping.hs
+++ b/library/Amy/TypeCheck/Subtyping.hs
@@ -24,35 +24,32 @@ import Amy.TypeCheck.Monad
 --
 
 subtype :: Type -> Type -> Checker ()
-subtype t1 t2 =
-  -- N.B. Removing all LocatedType nodes makes this logic simpler.
-  subtype' (removeLocatedType t1) (removeLocatedType t2)
-
-subtype' :: Type -> Type -> Checker ()
-subtype' (TyCon a) (TyCon b) | a == b = pure ()
-subtype' (TyVar a) (TyVar b) | a == b = pure ()
-subtype' (TyExistVar a) (TyExistVar b) | a == b = pure ()
-subtype' (TyApp t1 t2) (TyApp t1' t2') = subtypeMany [t1, t2] [t1', t2']
-subtype' (TyFun t1 t2) (TyFun t1' t2') = subtypeMany [t1, t2] [t1', t2']
-subtype' (TyForall as t1) t2 =
+subtype (TyCon (MaybeLocated _ a)) (TyCon (MaybeLocated _ b)) | a == b = pure ()
+subtype (TyVar (MaybeLocated _ a)) (TyVar (MaybeLocated _ b)) | a == b = pure ()
+subtype (TyExistVar a) (TyExistVar b) | a == b = pure ()
+subtype (TyApp t1 t2) (TyApp t1' t2') = subtypeMany [t1, t2] [t1', t2']
+subtype (TyFun t1 t2) (TyFun t1' t2') = subtypeMany [t1, t2] [t1', t2']
+subtype (TyForall as t1) t2 =
   withNewContextScope $ do
     as' <- traverse (const freshTyExistVar) as
-    let t1' = foldl' (\t (a, a') -> instantiate a (TyExistVar a') t) t1 $ NE.zip as as'
-    subtype' t1' t2
-subtype' t1 (TyForall as t2) =
-  withContextUntilNE (ContextVar <$> as) $
-    subtype' t1 t2
-subtype' (TyExistVar a) t = occursCheck a t >> instantiateLeft a t
-subtype' t (TyExistVar a) = occursCheck a t >> instantiateRight t a
-subtype' t1@(TyRecord rows1 mTail1) t2@(TyRecord rows2 mTail2) = do
+    let t1' = foldl' (\t (MaybeLocated _ a, a') -> instantiate a (TyExistVar a') t) t1 $ NE.zip as as'
+    subtype t1' t2
+subtype t1 (TyForall as t2) =
+  withContextUntilNE (ContextVar . maybeLocatedValue <$> as) $
+    subtype t1 t2
+subtype (TyExistVar a) t = occursCheck a t >> instantiateLeft a t
+subtype t (TyExistVar a) = occursCheck a t >> instantiateRight t a
+subtype t1@(TyRecord rows1 mTail1) t2@(TyRecord rows2 mTail2) = do
   -- TODO: This logic was copy/pasted and modified from old unification code.
   -- This probably needs to be audited to make sure it is actually checking for
   -- subtyping in the correct order (that is, t1 is a subtype of t2) and we
   -- aren't accidentally switching things around.
   let
-    commonFields = Map.intersectionWith (,) rows1 rows2
-    justFields1 = Map.difference rows1 rows2
-    justFields2 = Map.difference rows2 rows1
+    rows1' = Map.mapKeys maybeLocatedValue rows1
+    rows2' = Map.mapKeys maybeLocatedValue rows2
+    commonFields = Map.intersectionWith (,) rows1' rows2'
+    justFields1 = Map.difference rows1' rows2'
+    justFields2 = Map.difference rows2' rows1'
     -- We only need fresh type variables for record tails if there are
     -- differences between the records.
     maybeFreshTail distinctRows x =
@@ -60,7 +57,7 @@ subtype' t1@(TyRecord rows1 mTail1) t2@(TyRecord rows2 mTail2) = do
       then pure x
       else TyExistVar <$> freshTyExistVar
     subtypeRecordWithVar rows mTail mUnifyVar = do
-      recordTy <- currentContextSubst $ TyRecord rows mTail
+      recordTy <- currentContextSubst $ TyRecord (Map.mapKeys notLocated rows) mTail
       mTail' <- traverse currentContextSubst mTail
       mUnifyVar' <- traverse currentContextSubst mUnifyVar
       case (Map.null rows, mTail', mUnifyVar') of
@@ -68,11 +65,11 @@ subtype' t1@(TyRecord rows1 mTail1) t2@(TyRecord rows2 mTail2) = do
         -- unifying an empty row with an empty row.
         (True, Nothing, Nothing) -> pure ()
         -- Distinct rows are empty but there are type variables so unify them
-        (True, Just tail', Just unifyVar) -> subtype' tail' unifyVar
+        (True, Just tail', Just unifyVar) -> subtype tail' unifyVar
         -- Rows are empty and we are unifying with the empty row.
         (True, Just tail', Nothing) -> subtype tail' (TyRecord Map.empty Nothing)
         -- Base case, unify the record with the unify var
-        (_, _, Just unifyVar) -> subtype' recordTy unifyVar
+        (_, _, Just unifyVar) -> subtype recordTy unifyVar
         (_, _, _) -> throwAmyError $ UnificationFail t1 t2
 
   -- Unify common fields
@@ -83,7 +80,7 @@ subtype' t1@(TyRecord rows1 mTail1) t2@(TyRecord rows2 mTail2) = do
   -- Vice versa, unifying rows from second record with first variable.
   mTail2' <- traverse (maybeFreshTail justFields1) mTail2
   subtypeRecordWithVar justFields2 mTail2' mTail1
-subtype' t1 t2 = throwAmyError $ UnificationFail t1 t2
+subtype t1 t2 = throwAmyError $ UnificationFail t1 t2
 
 subtypeMany :: [Type] -> [Type] -> Checker ()
 subtypeMany [] [] = pure ()
@@ -113,7 +110,6 @@ freeTEVars' (TyApp a b) = freeTEVars a ++ freeTEVars b
 freeTEVars' (TyRecord rows mTail) = concat $ (freeTEVars <$> Map.elems rows) ++ maybeToList (freeTEVars <$> mTail)
 freeTEVars' (TyFun a b) = freeTEVars a ++ freeTEVars b
 freeTEVars' (TyForall _ t) = freeTEVars t
-freeTEVars' (LocatedType _ t) = freeTEVars t
 
 --
 -- Instantiate
@@ -122,7 +118,7 @@ freeTEVars' (LocatedType _ t) = freeTEVars t
 instantiate :: TyVarName -> Type -> Type -> Type
 instantiate v s = go
  where
-  go t@(TyVar v')
+  go t@(TyVar (MaybeLocated _ v'))
    | v == v' = s
    | otherwise = t
   go t = traverseType go t
@@ -139,7 +135,7 @@ instantiateLeft a (TyApp t1 t2) = do
   t2' <- currentContextSubst t2
   instantiateLeft a2 t2'
 instantiateLeft a (TyForall bs t) =
-  withContextUntilNE (ContextVar <$> bs) $
+  withContextUntilNE (ContextVar . maybeLocatedValue <$> bs) $
     instantiateLeft a t
 instantiateLeft a (TyRecord rows mTail) = do
   tysAndVars <- articulateRecord a rows mTail
@@ -163,7 +159,7 @@ instantiateRight (TyApp t1 t2) a = do
 instantiateRight (TyForall bs t) a =
   withNewContextScope $ do
     bs' <- traverse (const freshTyExistVar) bs
-    let t' = foldl' (\ty (b, b') -> instantiate b (TyExistVar b') ty) t $ NE.zip bs bs'
+    let t' = foldl' (\ty (MaybeLocated _ b, b') -> instantiate b (TyExistVar b') ty) t $ NE.zip bs bs'
     instantiateRight t' a
 instantiateRight (TyRecord rows mTail) a = do
   tysAndVars <- articulateRecord a rows mTail
@@ -187,7 +183,7 @@ articulateTyAppExist' f a = do
   putContext $ contextL |> ContextEVar a2 |> ContextEVar a1 |> ContextSolved a (f (TyExistVar a1) (TyExistVar a2)) <> contextR
   pure (a1, a2)
 
-articulateRecord :: TyExistVarName -> Map RowLabel Type -> Maybe Type -> Checker [(Type, TyExistVarName)]
+articulateRecord :: TyExistVarName -> Map (MaybeLocated RowLabel) Type -> Maybe Type -> Checker [(Type, TyExistVarName)]
 articulateRecord a rows mTail = do
   (contextL, contextR) <- findTEVarHole a
   rowsAndVars <- traverse (\t -> (t,) <$> freshTyExistVarNoContext) rows

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -302,6 +302,7 @@ patternBinderType (T.PParens pat) = patternBinderType pat
 --
 
 checkBinding :: S.Binding -> T.Type -> Checker T.Binding
+checkBinding binding (LocatedType _ ty) = checkBinding binding ty
 checkBinding binding (T.TyForall as t) =
   withContextUntilNE (ContextVar <$> as) $
     checkBinding binding t
@@ -344,6 +345,7 @@ checkExpr :: S.Expr -> T.Type -> Checker T.Expr
 checkExpr e t = withSourceSpan (expressionSpan e) $ checkExpr' e t
 
 checkExpr' :: S.Expr -> T.Type -> Checker T.Expr
+checkExpr' e (LocatedType _ ty) = checkExpr' e ty
 checkExpr' e (T.TyForall as t) =
   withContextUntilNE (ContextVar <$> as) $
     checkExpr e t

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -415,21 +415,19 @@ mkDataConTypes (S.TypeDeclaration (S.TyConDefinition (Located _ tyConName) tyVar
     in (name, tyForall)
 
 convertType :: S.Type -> T.Type
-convertType (S.TyCon (Located _ con)) = T.TyCon con
-convertType (S.TyVar var) = T.TyVar (convertTyVarInfo var)
+convertType (S.TyCon con) = T.TyCon con
+convertType (S.TyVar var) = T.TyVar var
 convertType (S.TyApp f arg) = T.TyApp (convertType f) (convertType arg)
 convertType (S.TyRecord rows mTail) =
   T.TyRecord
-    (Map.mapKeys locatedValue $ convertType <$> rows)
-    (T.TyVar . locatedValue <$> mTail)
+    (convertType <$> rows)
+    (T.TyVar <$> mTail)
 convertType (S.TyFun ty1 ty2) = T.TyFun (convertType ty1) (convertType ty2)
-convertType (S.TyForall vars ty) = T.TyForall (convertTyVarInfo <$> vars) (convertType ty)
+convertType (S.TyForall vars ty) = T.TyForall vars (convertType ty)
+convertType (LocatedType _ ty) = convertType ty
 
 convertTyConDefinition :: S.TyConDefinition -> T.TyConDefinition
 convertTyConDefinition (S.TyConDefinition (Located _ name') args) = T.TyConDefinition name' (locatedValue <$> args)
-
-convertTyVarInfo :: Located TyVarName -> T.TyVarName
-convertTyVarInfo (Located _ name') = name'
 
 --
 -- Substitution

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -37,7 +37,7 @@ match'
 match' vars eqs = runDesugar [] $ match vars eqs
 
 boolTy :: Type
-boolTy = TyCon "Bool"
+boolTy = TyCon (notLocated "Bool")
 
 mkExpr :: [Typed IdentName] -> Expr
 mkExpr [] = error "empty list"

--- a/tests/Amy/Syntax/ParserSpec.hs
+++ b/tests/Amy/Syntax/ParserSpec.hs
@@ -30,14 +30,14 @@ spec = do
         `shouldParse`
         Extern
           (Located (SourceSpan "" 1 8 1 8) "f")
-          (TyCon $ Located (SourceSpan "" 1 13 1 15) "Int")
+          (LocatedType (SourceSpan "" 1 13 1 15) (TyCon "Int"))
       parse' externDecl "extern f :: Int -> Double"
         `shouldParse`
         Extern
           (Located (SourceSpan "" 1 8 1 8) "f")
-          ( TyCon (Located (SourceSpan "" 1 13 1 15) "Int")
+          ( LocatedType (SourceSpan "" 1 13 1 15) (TyCon "Int")
             `TyFun`
-            TyCon (Located (SourceSpan "" 1 20 1 25) "Double")
+            LocatedType (SourceSpan "" 1 20 1 25) (TyCon "Double")
           )
 
   describe "bindingType" $ do
@@ -46,14 +46,14 @@ spec = do
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
-          (TyCon (Located (SourceSpan "" 1 6 1 8) "Int"))
+          (LocatedType (SourceSpan "" 1 6 1 8) (TyCon "Int"))
       parse' bindingType "f :: Int -> Double"
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
-          ( TyCon (Located (SourceSpan "" 1 6 1 8) "Int")
+          ( LocatedType (SourceSpan "" 1 6 1 8) (TyCon "Int")
             `TyFun`
-            TyCon (Located (SourceSpan "" 1 13 1 18) "Double")
+            LocatedType (SourceSpan "" 1 13 1 18) (TyCon "Double")
           )
 
     it "parses polymorphic types" $ do
@@ -61,99 +61,97 @@ spec = do
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
-          (TyForall [Located (SourceSpan "" 1 13 1 13) "a"] $ TyVar (Located (SourceSpan "" 1 16 1 16) "a"))
+          (TyForall ["a"] $ LocatedType (SourceSpan "" 1 16 1 16) (TyVar "a"))
       parse' bindingType "f :: forall a b. a -> b -> a"
         `shouldParse`
         BindingType
           (Located (SourceSpan "" 1 1 1 1) "f")
-          ( TyForall
-              [ Located (SourceSpan "" 1 13 1 13) "a"
-              , Located (SourceSpan "" 1 15 1 15) "b"] $
-            TyVar (Located (SourceSpan "" 1 18 1 18) "a")
-            `TyFun`
-            TyVar ( Located (SourceSpan "" 1 23 1 23) "b")
-            `TyFun`
-            TyVar ( Located (SourceSpan "" 1 28 1 28) "a")
+          ( TyForall ["a", "b"] $
+              LocatedType (SourceSpan "" 1 18 1 18) (TyVar "a")
+              `TyFun`
+              LocatedType (SourceSpan "" 1 23 1 23) (TyVar "b")
+              `TyFun`
+              LocatedType (SourceSpan "" 1 28 1 28) (TyVar "a")
           )
 
   describe "parseType" $ do
     it "handles simple terms" $ do
-      parse' parseType "A" `shouldParse` TyCon (Located (SourceSpan "" 1 1 1 1) "A")
-      parse' parseType "a" `shouldParse` TyVar (Located (SourceSpan "" 1 1 1 1) "a")
+      parse' parseType "A" `shouldParse` LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A")
+      parse' parseType "a" `shouldParse` LocatedType (SourceSpan "" 1 1 1 1) (TyVar "a")
 
     it "handles terms with args" $ do
       parse' parseType "A a" `shouldParse`
-        TyApp (TyCon $ Located (SourceSpan "" 1 1 1 1) "A") (TyVar (Located (SourceSpan "" 1 3 1 3) "a"))
+        (LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A") `TyApp` LocatedType (SourceSpan "" 1 3 1 3) (TyVar "a"))
 
     it "tightly binds constructor applications" $ do
       parse' parseType "A B C" `shouldParse`
         TyApp
           ( TyApp
-            (TyCon $ Located (SourceSpan "" 1 1 1 1) "A")
-            (TyCon (Located (SourceSpan "" 1 3 1 3) "B"))
+            (LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A"))
+            (LocatedType (SourceSpan "" 1 3 1 3) (TyCon "B"))
           )
-          (TyCon (Located (SourceSpan "" 1 5 1 5) "C"))
+          (LocatedType (SourceSpan "" 1 5 1 5) (TyCon "C"))
 
     it "handles terms with args and parens" $ do
       parse' parseType "A (B b) a" `shouldParse`
         TyApp
         ( TyApp
-          (TyCon $ Located (SourceSpan "" 1 1 1 1) "A")
+          (LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A"))
           ( TyApp
-            (TyCon $ Located (SourceSpan "" 1 4 1 4) "B")
-            (TyVar (Located (SourceSpan "" 1 6 1 6) "b"))
+            (LocatedType (SourceSpan "" 1 4 1 4) (TyCon "B"))
+            (LocatedType (SourceSpan "" 1 6 1 6) (TyVar "b"))
           )
         )
-        (TyVar (Located (SourceSpan "" 1 9 1 9) "a"))
+        (LocatedType (SourceSpan "" 1 9 1 9) (TyVar "a"))
 
   describe "parseType" $ do
     it "handles simple types" $ do
-      parse' parseType "A" `shouldParse` TyCon (Located (SourceSpan "" 1 1 1 1) "A")
+      parse' parseType "A" `shouldParse` LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A")
       parse' parseType "A -> B"
         `shouldParse` (
-          TyCon (Located (SourceSpan "" 1 1 1 1) "A")
+          LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A")
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 6 1 6) "B")
+          LocatedType (SourceSpan "" 1 6 1 6) (TyCon "B")
         )
       parse' parseType "A -> B -> C"
         `shouldParse` (
-          TyCon (Located (SourceSpan "" 1 1 1 1) "A")
+          LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A")
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 6 1 6) "B")
+          LocatedType (SourceSpan "" 1 6 1 6) (TyCon "B")
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 11 1 11) "C")
+          LocatedType (SourceSpan "" 1 11 1 11) (TyCon "C")
         )
 
     it "handles parens" $ do
-      parse' parseType "(A)" `shouldParse` TyCon (Located (SourceSpan "" 1 2 1 2) "A")
-      parse' parseType "((X))" `shouldParse` TyCon (Located (SourceSpan "" 1 3 1 3) "X")
+      parse' parseType "(A)" `shouldParse` LocatedType (SourceSpan "" 1 2 1 2) (TyCon "A")
+      parse' parseType "((X))" `shouldParse` LocatedType (SourceSpan "" 1 3 1 3) (TyCon "X")
 
     it "handles parens with functions" $ do
       parse' parseType "((A)) -> ((B))"
         `shouldParse` (
-          TyCon (Located (SourceSpan "" 1 3 1 3) "A")
+          LocatedType (SourceSpan "" 1 3 1 3) (TyCon "A")
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 12 1 12) "B")
+          LocatedType (SourceSpan "" 1 12 1 12) (TyCon "B")
         )
       parse' parseType "(A -> B) -> C"
         `shouldParse` (
-          ( TyCon (Located (SourceSpan "" 1 2 1 2) "A")
+          ( LocatedType (SourceSpan "" 1 2 1 2) (TyCon "A")
             `TyFun`
-            TyCon (Located (SourceSpan "" 1 7 1 7) "B")
+            LocatedType (SourceSpan "" 1 7 1 7) (TyCon "B")
           )
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 13 1 13) "C")
+          LocatedType (SourceSpan "" 1 13 1 13) (TyCon "C")
         )
       parse' parseType "A -> (B -> C) -> D"
         `shouldParse` (
-          TyCon (Located (SourceSpan "" 1 1 1 1) "A")
+          LocatedType (SourceSpan "" 1 1 1 1) (TyCon "A")
           `TyFun`
-          ( TyCon (Located (SourceSpan "" 1 7 1 7) "B")
+          ( LocatedType (SourceSpan "" 1 7 1 7) (TyCon "B")
             `TyFun`
-             TyCon (Located (SourceSpan "" 1 12 1 12) "C")
+             LocatedType (SourceSpan "" 1 12 1 12) (TyCon "C")
           )
           `TyFun`
-          TyCon (Located (SourceSpan "" 1 18 1 18) "D")
+          LocatedType (SourceSpan "" 1 18 1 18) (TyCon "D")
         )
 
     it "should fail gracefully without infinite loops" $ do

--- a/tests/Amy/Syntax/ParserSpec.hs
+++ b/tests/Amy/Syntax/ParserSpec.hs
@@ -22,7 +22,7 @@ parse' parser input =
   in parse (runAmyParser parser) "" tokens'
 
 mkSpan :: Int -> Int -> Int -> Int -> SourceSpan
-mkSpan startLine startCol endLine endCol = SourceSpan (mkSourcePos "" startLine startCol) (mkSourcePos "" endLine endCol)
+mkSpan = mkSourceSpan ""
 
 mkLocated :: Int -> Int -> Int -> Int -> a -> MaybeLocated a
 mkLocated startLine startCol endLine endCol x = MaybeLocated (Just $ mkSpan startLine startCol endLine endCol) x


### PR DESCRIPTION
I began work on a module system, and learned that the duplication between ASTs is a huge pain when I tried to implement interfaces and symbol tables for modules. In particular, duplicating `Type` and `TypeDeclaration` across ASTs meant I couldn't share symbol tables with those things across the different ASTs, and a generic `Environment` for a module would have to have a copy for each of type checking, Core, and ANF.

This PR is also nice because code duplication in general isn't the best unless there is a good reason to have it. I'm going to try and do more deduplication between the Syntax and TypeCheck ASTs, but we'll see how ergonomic that ends up being.