### PR TITLE
Environments and implicit prelude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: $(RTS_LL)
 test: $(RTS_LL)
 	stack test --pedantic amy
 	stack test --pedantic amy-integration-tests
-	(cd integration-tests && RTS_LL_LOCATION=../rts/rts.ll stack exec amy-integration-tests)
+	(cd integration-tests && PRELUDE_LOCATION=../stdlib/prelude.amy RTS_LL_LOCATION=../rts/rts.ll stack exec amy-integration-tests)
 
 .PHONY: watch
 watch:

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -68,7 +68,9 @@ process filePath DumpFlags{..} input = do
       lift $ writeFile (filePath `replaceExtension` ".amy-core-lifted") (show $ C.prettyModule lifted)
 
     -- Normalize to ANF
-    let anf = normalizeModule lifted
+    let
+      anfEnv = coreEnv
+      anf = normalizeModule lifted anfEnv
     when dfDumpANF $
       lift $ writeFile (filePath `replaceExtension` ".amy-anf") (show $ ANF.prettyModule anf)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -70,7 +70,7 @@ process filePath DumpFlags{..} input = do
     -- Normalize to ANF
     let
       anfEnv = coreEnv
-      anf = normalizeModule lifted anfEnv
+      (anf, _) = normalizeModule lifted anfEnv
     when dfDumpANF $
       lift $ writeFile (filePath `replaceExtension` ".amy-anf") (show $ ANF.prettyModule anf)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -51,12 +51,14 @@ process filePath DumpFlags{..} input = do
       lift $ writeFile (filePath `replaceExtension` ".amy-parsed") (show $ S.prettyModule parsed)
 
     -- Type checking
-    typeChecked <- liftEither $ first ((:[]) . showError) $ TC.inferModule primEnvironment parsed
+    (typeChecked, typeCheckedEnv) <- liftEither $ first ((:[]) . showError) $ TC.inferModule primEnvironment parsed
     when dfDumpTypeChecked $
       lift $ writeFile (filePath `replaceExtension` ".amy-typechecked") (show $ S.prettyModule typeChecked)
 
     -- Desugar to Core
-    let core = desugarModule primEnvironment typeChecked
+    let
+      coreEnv = mergeEnvironments primEnvironment typeCheckedEnv
+      core = desugarModule coreEnv typeChecked
     when dfDumpCore $
       lift $ writeFile (filePath `replaceExtension` ".amy-core") (show $ C.prettyModule core)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -6,13 +6,17 @@ module Main
   ( main
   ) where
 
+import Control.Monad.Except
 import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text.IO as T
 import Options.Applicative
+import System.Environment (lookupEnv)
 import System.Exit (die)
 
 import Amy.Compile
+import Amy.Environment
 
 main :: IO ()
 main =
@@ -26,8 +30,18 @@ compileFile CompileFileOptions{..} = T.readFile cfoFilePath >>= process cfoFileP
 
 process :: FilePath -> DumpFlags -> Text -> IO ()
 process filePath dumpFlags input = do
-  eCompiledModule <- compileModule filePath dumpFlags input
-  either (die . intercalate "\n") (linkModules []) eCompiledModule
+  preludePath <- fromMaybe "stdlib/prelude.amy" <$> lookupEnv "PRELUDE_LOCATION"
+  preludeText <- T.readFile preludePath
+
+  eFailure <- runExceptT $ do
+    prelude@(CompiledModule preludeEnv _) <- ExceptT $ compileModule primEnvironment preludePath dumpFlags preludeText
+    let preludeEnv' = preludeEnv `mergeEnvironments` primEnvironment
+    compiledModule <- ExceptT $ compileModule preludeEnv' filePath dumpFlags input
+
+    rtsLL <- fromMaybe "rts/rts.ll" <$> lift (lookupEnv "RTS_LL_LOCATION")
+    liftIO $ linkModules [prelude] compiledModule rtsLL
+
+  either (die . intercalate "\n") pure eFailure
 
 -- runRepl :: IO ()
 -- runRepl = runInputT defaultSettings loop

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -26,6 +26,7 @@ import Text.Megaparsec
 import Amy.ANF as ANF
 import Amy.Codegen
 import Amy.Core as C
+import Amy.Environment
 import Amy.Errors
 import Amy.Syntax as S
 import Amy.TypeCheck as TC
@@ -50,7 +51,7 @@ process filePath DumpFlags{..} input = do
       lift $ writeFile (filePath `replaceExtension` ".amy-parsed") (show $ S.prettyModule parsed)
 
     -- Type checking
-    typeChecked <- liftEither $ first ((:[]) . showError) $ TC.inferModule parsed
+    typeChecked <- liftEither $ first ((:[]) . showError) $ TC.inferModule primEnvironment parsed
     when dfDumpTypeChecked $
       lift $ writeFile (filePath `replaceExtension` ".amy-typechecked") (show $ S.prettyModule typeChecked)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -26,8 +26,8 @@ compileFile CompileFileOptions{..} = T.readFile cfoFilePath >>= process cfoFileP
 
 process :: FilePath -> DumpFlags -> Text -> IO ()
 process filePath dumpFlags input = do
-  eResult <- compileModule filePath dumpFlags input
-  either (die . intercalate "\n") pure eResult
+  eCompiledModule <- compileModule filePath dumpFlags input
+  either (die . intercalate "\n") (linkModules []) eCompiledModule
 
 -- runRepl :: IO ()
 -- runRepl = runInputT defaultSettings loop

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -56,7 +56,7 @@ process filePath DumpFlags{..} input = do
       lift $ writeFile (filePath `replaceExtension` ".amy-typechecked") (show $ S.prettyModule typeChecked)
 
     -- Desugar to Core
-    let core = desugarModule typeChecked
+    let core = desugarModule primEnvironment typeChecked
     when dfDumpCore $
       lift $ writeFile (filePath `replaceExtension` ".amy-core") (show $ C.prettyModule core)
 

--- a/executables/Main.hs
+++ b/executables/Main.hs
@@ -6,30 +6,13 @@ module Main
   ( main
   ) where
 
-import Control.Monad (when)
-import Control.Monad.Except
-import Data.Bifunctor (first)
-import qualified Data.ByteString.Char8 as BS8
 import Data.List (intercalate)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text.IO as T
-import qualified Data.Text.Lazy.IO as TL
-import LLVM.Pretty (ppllvm)
 import Options.Applicative
-import System.Environment (lookupEnv)
 import System.Exit (die)
-import System.FilePath.Posix ((</>), dropExtension, replaceExtension, takeDirectory)
-import System.Process (callProcess)
-import Text.Megaparsec
 
-import Amy.ANF as ANF
-import Amy.Codegen
-import Amy.Core as C
-import Amy.Environment
-import Amy.Errors
-import Amy.Syntax as S
-import Amy.TypeCheck as TC
+import Amy.Compile
 
 main :: IO ()
 main =
@@ -42,64 +25,8 @@ compileFile :: CompileFileOptions -> IO ()
 compileFile CompileFileOptions{..} = T.readFile cfoFilePath >>= process cfoFilePath cfoDumpFlags
 
 process :: FilePath -> DumpFlags -> Text -> IO ()
-process filePath DumpFlags{..} input = do
-  eResult <- runExceptT $ do
-    -- Parse
-    tokens' <- liftEither $ first ((:[]) . parseErrorPretty) $ lexer filePath input
-    parsed <- liftEither $ first ((:[]) . parseErrorPretty) $ parse (runAmyParser parseModule) filePath tokens'
-    when dfDumpParsed $
-      lift $ writeFile (filePath `replaceExtension` ".amy-parsed") (show $ S.prettyModule parsed)
-
-    -- Type checking
-    (typeChecked, typeCheckedEnv) <- liftEither $ first ((:[]) . showError) $ TC.inferModule primEnvironment parsed
-    when dfDumpTypeChecked $
-      lift $ writeFile (filePath `replaceExtension` ".amy-typechecked") (show $ S.prettyModule typeChecked)
-
-    -- Desugar to Core
-    let
-      coreEnv = mergeEnvironments primEnvironment typeCheckedEnv
-      core = desugarModule coreEnv typeChecked
-    when dfDumpCore $
-      lift $ writeFile (filePath `replaceExtension` ".amy-core") (show $ C.prettyModule core)
-
-    -- Prepare for ANF
-    let lifted = lambdaLifting core
-    when dfDumpCoreLifted $
-      lift $ writeFile (filePath `replaceExtension` ".amy-core-lifted") (show $ C.prettyModule lifted)
-
-    -- Normalize to ANF
-    let
-      anfEnv = coreEnv
-      (anf, _) = normalizeModule lifted anfEnv
-    when dfDumpANF $
-      lift $ writeFile (filePath `replaceExtension` ".amy-anf") (show $ ANF.prettyModule anf)
-
-    -- Codegen to pure LLVM
-    let llvmAST = codegenModule anf
-    when dfDumpLLVMPretty $
-      lift $ TL.writeFile (filePath `replaceExtension` ".ll-pretty") (ppllvm llvmAST)
-
-    -- Generate LLVM IR using C++ API
-    let llvmFile = filePath `replaceExtension` ".ll"
-    llvm <- lift $ generateLLVMIR llvmAST
-    lift $ BS8.writeFile llvmFile llvm
-
-    -- Link RTS
-    let linkedLL = dropExtension filePath ++ "-rts-linked.ll"
-    rtsLL <- fromMaybe "rts/rts.ll" <$> lift (lookupEnv "RTS_LL_LOCATION")
-    linked <- lift $ linkRTS rtsLL llvmFile
-    lift $ BS8.writeFile linkedLL linked
-
-    -- Optimize LLVM
-    -- TODO: This breaks some examples
-    -- let optLL = dropExtension filePath ++ "-rts-opt.ll"
-    -- opt <- lift $ optimizeLLVM linkedLL
-    -- lift $ BS8.writeFile optLL opt
-
-    -- Compile with clang
-    let exeFile = takeDirectory filePath </> "a.out"
-    lift $ callProcess "clang" ["-lgc", "-o", exeFile, linkedLL]
-
+process filePath dumpFlags input = do
+  eResult <- compileModule filePath dumpFlags input
   either (die . intercalate "\n") pure eResult
 
 -- runRepl :: IO ()
@@ -141,28 +68,6 @@ data CompileFileOptions
   , cfoDumpFlags :: !DumpFlags
   } deriving (Show, Eq)
 
-data DumpFlags
-  = DumpFlags
-  { dfDumpParsed :: !Bool
-  , dfDumpTypeChecked :: !Bool
-  , dfDumpCore :: !Bool
-  , dfDumpCoreLifted :: !Bool
-  , dfDumpANF :: !Bool
-  , dfDumpLLVMPretty :: !Bool
-  --, dfDumpLLVM :: !Bool
-  } deriving (Show, Eq)
-
--- dumpFlags :: DumpFlags
--- dumpFlags =
---   DumpFlags
---   { dfDumpParsed = False
---   , dfDumpTypeChecked = False
---   , dfDumpCore = False
---   , dfDumpANF = False
---   , dfDumpLLVMPretty = False
---   , dfDumpLLVM = False
---   }
-
 parseCompileFile :: Parser CompileFileOptions
 parseCompileFile =
   CompileFileOptions
@@ -181,4 +86,3 @@ parseDumpFlags =
   <*> switch (long "dump-core-lifted" <> helpDoc (Just "Dump lifted Core AST"))
   <*> switch (long "dump-anf" <> helpDoc (Just "Dump ANF AST"))
   <*> switch (long "dump-llvm-pretty" <> helpDoc (Just "Dump pure LLVM AST from llvm-hs-pretty"))
-  -- <*> switch (long "dump-llvm" <> helpDoc (Just "Dump LLVM IR"))

--- a/integration-tests/pass/closures/closures.ll
+++ b/integration-tests/pass/closures/closures.ll
@@ -47,7 +47,7 @@ entry:
   ret %struct.Closure* %6
 }
 
-define private %struct.Closure* @myAddDouble(double %x) {
+define %struct.Closure* @myAddDouble(double %x) {
 entry:
   %"lambda1_$2_closure1" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda1_$2_closure_wrapper")
   %0 = call i8* @GC_malloc(i64 64)
@@ -62,20 +62,20 @@ entry:
   ret %struct.Closure* %ret
 }
 
-define private i64 @myAdd(i64 %x, double %y) {
+define i64 @myAdd(i64 %x, double %y) {
 entry:
   %res2 = fptoui double %y to i64
   %ret = add i64 %x, %res2
   ret i64 %ret
 }
 
-define private %struct.Closure* @incDouble() {
+define %struct.Closure* @incDouble() {
 entry:
   %ret = call %struct.Closure* @myAddDouble(double 1.010000e+00)
   ret %struct.Closure* %ret
 }
 
-define private %struct.Closure* @inc() {
+define %struct.Closure* @inc() {
 entry:
   %myAdd_closure3 = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @myAdd_closure_wrapper)
   %0 = call i8* @GC_malloc(i64 64)
@@ -111,7 +111,7 @@ entry:
   ret i64 %ret
 }
 
-define private double @"lambda1_$2"(double %x, double %y) {
+define double @"lambda1_$2"(double %x, double %y) {
 entry:
   %ret = fadd double %x, %y
   ret double %ret

--- a/integration-tests/pass/data/data.ll
+++ b/integration-tests/pass/data/data.ll
@@ -6,7 +6,7 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define private i64 @f(double %x, i8 %enum) {
+define i64 @f(double %x, i8 %enum) {
 entry:
   switch i8 %enum, label %case.0.ret [
     i8 0, label %case.0.ret
@@ -35,7 +35,7 @@ case.end.ret:                                     ; preds = %case.2.ret, %case.1
   ret i64 %ret
 }
 
-define private i64 @countNat(%Nat* %n) {
+define i64 @countNat(%Nat* %n) {
 entry:
   %0 = getelementptr %Nat, %Nat* %n, i32 0, i32 0
   %1 = load i1, i1* %0

--- a/integration-tests/pass/fib/fib.ll
+++ b/integration-tests/pass/fib/fib.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-define private i64 @fib(i64 %x) {
+define i64 @fib(i64 %x) {
 entry:
   switch i64 %x, label %case.default.ret [
     i64 0, label %case.0.ret

--- a/integration-tests/pass/funcargs/funcargs.ll
+++ b/integration-tests/pass/funcargs/funcargs.ll
@@ -20,7 +20,7 @@ entry:
   ret %struct.Closure* %5
 }
 
-define private i64 @apply(%struct.Closure* %f) {
+define i64 @apply(%struct.Closure* %f) {
 entry:
   %0 = call i8* @GC_malloc(i64 128)
   %1 = bitcast i8* %0 to i64*
@@ -40,7 +40,7 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @"lambda3_$4"(i64 %_x1, i64 %_x2) {
+define i64 @"lambda3_$4"(i64 %_x1, i64 %_x2) {
 entry:
   %ret = add i64 %_x1, %_x2
   ret i64 %ret

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.amy
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.amy
@@ -1,8 +1,5 @@
 main :: Int
 main = idFancy id 1
 
-id :: forall a. a -> a
-id x = x
-
 idFancy :: forall a. (forall b. b -> b) -> a -> a
 idFancy f x = f x

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
@@ -9,6 +9,8 @@ declare %struct.Closure* @call_closure(%struct.Closure*, i8, i64*)
 
 declare %struct.Closure* @create_closure(i8, %struct.Closure* (i64*)*)
 
+declare i64* @id(i64*)
+
 define private %struct.Closure* @id_closure_wrapper(i64* %env) {
 entry:
   %0 = getelementptr i64, i64* %env, i32 0
@@ -28,14 +30,6 @@ entry:
   store i64* %x, i64** %3
   %4 = call %struct.Closure* @call_closure(%struct.Closure* %f, i8 1, i64* %1)
   %ret = bitcast %struct.Closure* %4 to i64*
-  ret i64* %ret
-}
-
-define i64* @id(i64* %x) {
-entry:
-  %0 = alloca i64*
-  store i64* %x, i64** %0
-  %ret = load i64*, i64** %0
   ret i64* %ret
 }
 

--- a/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
+++ b/integration-tests/pass/higher-rank-poly/higher-rank-poly.ll
@@ -19,7 +19,7 @@ entry:
   ret %struct.Closure* %4
 }
 
-define private i64* @idFancy(%struct.Closure* %f, i64* %x) {
+define i64* @idFancy(%struct.Closure* %f, i64* %x) {
 entry:
   %0 = call i8* @GC_malloc(i64 64)
   %1 = bitcast i8* %0 to i64*
@@ -31,7 +31,7 @@ entry:
   ret i64* %ret
 }
 
-define private i64* @id(i64* %x) {
+define i64* @id(i64* %x) {
 entry:
   %0 = alloca i64*
   store i64* %x, i64** %0

--- a/integration-tests/pass/lambda-lift/lambda-lift.amy
+++ b/integration-tests/pass/lambda-lift/lambda-lift.amy
@@ -4,13 +4,13 @@ main :: Int
 main =
   let
     # Nested lift
-    id x =
+    id' x =
       let
-        id' y = x
-      in id' x
+        id'' y = x
+      in id'' x
 
-    # Depends on id
-    const x y = id y
+    # Depends on id'
+    const' x y = id' y
 
     # Needs closing
     z = 2
@@ -20,7 +20,7 @@ main =
     a = 1
     g x = if iLessThan# x 0 then 100 else g' (iSub# x z)
     g' x = g ((\y -> iAdd# x y) a)
-  in g (f (const 2 1))
+  in g (f (const' 2 1))
 
 mkJust :: forall a. a -> Maybe a
 mkJust = Just

--- a/integration-tests/pass/lambda-lift/lambda-lift.amy
+++ b/integration-tests/pass/lambda-lift/lambda-lift.amy
@@ -1,7 +1,5 @@
 # Demonstrate lambda lifting
 
-Maybe a = Nothing | Just a
-
 main :: Int
 main =
   let

--- a/integration-tests/pass/lambda-lift/lambda-lift.ll
+++ b/integration-tests/pass/lambda-lift/lambda-lift.ll
@@ -42,7 +42,7 @@ entry:
   ret %struct.Closure* %5
 }
 
-define private %struct.Closure* @mkJust() {
+define %struct.Closure* @mkJust() {
 entry:
   %"lambda2_$3_closure1" = call %struct.Closure* @create_closure(i8 1, %struct.Closure* (i64*)* @"lambda2_$3_closure_wrapper")
   %0 = alloca %struct.Closure*
@@ -79,7 +79,7 @@ entry:
   ret i64 %ret
 }
 
-define private %Maybe* @"lambda2_$3"(i64* %_x1) {
+define %Maybe* @"lambda2_$3"(i64* %_x1) {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint (%Maybe* getelementptr (%Maybe, %Maybe* null, i32 1) to i64))
   %ret = bitcast i8* %0 to %Maybe*
@@ -91,7 +91,7 @@ entry:
   ret %Maybe* %ret1
 }
 
-define private i64 @"id'_$5"(i64 %x, i64 %y) {
+define i64 @"id'_$5"(i64 %x, i64 %y) {
 entry:
   %0 = alloca i64
   store i64 %x, i64* %0
@@ -99,31 +99,31 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @"id_$4"(i64 %x) {
+define i64 @"id_$4"(i64 %x) {
 entry:
   %ret = call i64 @"id'_$5"(i64 %x, i64 %x)
   ret i64 %ret
 }
 
-define private i64 @"lambda7_$8"(i64 %z, i64 %_x6) {
+define i64 @"lambda7_$8"(i64 %z, i64 %_x6) {
 entry:
   %ret = add i64 %z, %_x6
   ret i64 %ret
 }
 
-define private i64 @"const_$9"(i64 %x, i64 %y) {
+define i64 @"const_$9"(i64 %x, i64 %y) {
 entry:
   %ret = call i64 @"id_$4"(i64 %y)
   ret i64 %ret
 }
 
-define private i64 @"lambda12_$13"(i64 %x, i64 %y) {
+define i64 @"lambda12_$13"(i64 %x, i64 %y) {
 entry:
   %ret = add i64 %x, %y
   ret i64 %ret
 }
 
-define private i64 @"g'_$10"(i64 %a, i64 %z, i64 %x) {
+define i64 @"g'_$10"(i64 %a, i64 %z, i64 %x) {
 entry:
   %"lambda12_$13_closure5" = call %struct.Closure* @create_closure(i8 2, %struct.Closure* (i64*)* @"lambda12_$13_closure_wrapper")
   %0 = call i8* @GC_malloc(i64 64)
@@ -144,7 +144,7 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @"g_$11"(i64 %a, i64 %z, i64 %x) {
+define i64 @"g_$11"(i64 %a, i64 %z, i64 %x) {
 entry:
   %res8 = icmp slt i64 %x, 0
   switch i1 %res8, label %case.0.ret [

--- a/integration-tests/pass/lambda-lift/lambda-lift.ll
+++ b/integration-tests/pass/lambda-lift/lambda-lift.ll
@@ -68,7 +68,7 @@ entry:
   %6 = alloca i64
   store i64 1, i64* %6
   %a = load i64, i64* %6
-  %res3 = call i64 @"const_$9"(i64 2, i64 1)
+  %res3 = call i64 @"const'_$9"(i64 2, i64 1)
   %7 = call i8* @GC_malloc(i64 64)
   %8 = bitcast i8* %7 to i64*
   %9 = getelementptr i64, i64* %8, i32 0
@@ -91,7 +91,7 @@ entry:
   ret %Maybe* %ret1
 }
 
-define i64 @"id'_$5"(i64 %x, i64 %y) {
+define i64 @"id''_$5"(i64 %x, i64 %y) {
 entry:
   %0 = alloca i64
   store i64 %x, i64* %0
@@ -99,9 +99,9 @@ entry:
   ret i64 %ret
 }
 
-define i64 @"id_$4"(i64 %x) {
+define i64 @"id'_$4"(i64 %x) {
 entry:
-  %ret = call i64 @"id'_$5"(i64 %x, i64 %x)
+  %ret = call i64 @"id''_$5"(i64 %x, i64 %x)
   ret i64 %ret
 }
 
@@ -111,9 +111,9 @@ entry:
   ret i64 %ret
 }
 
-define i64 @"const_$9"(i64 %x, i64 %y) {
+define i64 @"const'_$9"(i64 %x, i64 %y) {
 entry:
-  %ret = call i64 @"id_$4"(i64 %y)
+  %ret = call i64 @"id'_$4"(i64 %y)
   ret i64 %ret
 }
 

--- a/integration-tests/pass/let/let.ll
+++ b/integration-tests/pass/let/let.ll
@@ -3,7 +3,7 @@ source_filename = "<string>"
 
 declare i64 @abs(i64)
 
-define private i64 @threeHundred() {
+define i64 @threeHundred() {
 entry:
   %0 = alloca i64
   store i64 300, i64* %0
@@ -11,7 +11,7 @@ entry:
   ret i64 %ret
 }
 
-define private i64 @f(i64 %x) {
+define i64 @f(i64 %x) {
 entry:
   switch i1 true, label %case.0.ret [
     i1 true, label %case.0.ret

--- a/integration-tests/pass/poly-data/poly-data.amy
+++ b/integration-tests/pass/poly-data/poly-data.amy
@@ -1,5 +1,3 @@
-Either a b = Left a | Right b
-
 main :: Int
 main =
   case f of

--- a/integration-tests/pass/poly-data/poly-data.ll
+++ b/integration-tests/pass/poly-data/poly-data.ll
@@ -5,7 +5,7 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define private %Either* @h() {
+define %Either* @h() {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %res1 = bitcast i8* %0 to %Either*
@@ -28,7 +28,7 @@ entry:
   ret %Either* %ret2
 }
 
-define private %Either* @f() {
+define %Either* @f() {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint (%Either* getelementptr (%Either, %Either* null, i32 1) to i64))
   %res2 = bitcast i8* %0 to %Either*

--- a/integration-tests/pass/poly/poly.amy
+++ b/integration-tests/pass/poly/poly.amy
@@ -1,12 +1,6 @@
 main :: Int
 main = doubleToInt# (const (id 3.1) 5.1)
 
-id :: forall a. a -> a
-id x = x
-
-const :: forall a b. a -> b -> a
-const x y = x
-
 # TODO: Use this once we have lambda lifting and test tyvar scoping rules
 # const :: forall a b. a -> b -> a
 # const x y =

--- a/integration-tests/pass/poly/poly.ll
+++ b/integration-tests/pass/poly/poly.ll
@@ -3,21 +3,9 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define i64* @id(i64* %x) {
-entry:
-  %0 = alloca i64*
-  store i64* %x, i64** %0
-  %ret = load i64*, i64** %0
-  ret i64* %ret
-}
+declare i64* @const(i64*, i64*)
 
-define i64* @const(i64* %x, i64* %y) {
-entry:
-  %0 = alloca i64*
-  store i64* %x, i64** %0
-  %ret = load i64*, i64** %0
-  ret i64* %ret
-}
+declare i64* @id(i64*)
 
 define i64 @main() {
 entry:

--- a/integration-tests/pass/poly/poly.ll
+++ b/integration-tests/pass/poly/poly.ll
@@ -3,7 +3,7 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define private i64* @id(i64* %x) {
+define i64* @id(i64* %x) {
 entry:
   %0 = alloca i64*
   store i64* %x, i64** %0
@@ -11,7 +11,7 @@ entry:
   ret i64* %ret
 }
 
-define private i64* @const(i64* %x, i64* %y) {
+define i64* @const(i64* %x, i64* %y) {
 entry:
   %0 = alloca i64*
   store i64* %x, i64** %0

--- a/integration-tests/pass/primops/primops.ll
+++ b/integration-tests/pass/primops/primops.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'amy-module'
 source_filename = "<string>"
 
-define private i64 @f(i64 %x) {
+define i64 @f(i64 %x) {
 entry:
   %y = add i64 %x, -1
   %res2 = sub i64 3, %y

--- a/integration-tests/pass/records/records.ll
+++ b/integration-tests/pass/records/records.ll
@@ -5,7 +5,7 @@ source_filename = "<string>"
 
 declare i8* @GC_malloc(i64)
 
-define private { i64*, i64*, i64* }* @q({ i64*, i64*, i64* }* %r) {
+define { i64*, i64*, i64* }* @q({ i64*, i64*, i64* }* %r) {
 entry:
   %0 = getelementptr { i64*, i64*, i64* }, { i64*, i64*, i64* }* %r, i32 0, i32 0
   %x1 = load i64*, i64** %0
@@ -24,7 +24,7 @@ entry:
   ret { i64*, i64*, i64* }* %ret
 }
 
-define private %List* @h(i64* %x) {
+define %List* @h(i64* %x) {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint (%List* getelementptr (%List, %List* null, i32 1) to i64))
   %cdr4 = bitcast i8* %0 to %List*
@@ -62,7 +62,7 @@ entry:
   ret %List* %ret3
 }
 
-define private { i64*, i64 }* @g(i64* %x) {
+define { i64*, i64 }* @g(i64* %x) {
 entry:
   %0 = call i8* @GC_malloc(i64 ptrtoint ({ i64*, i64 }* getelementptr ({ i64*, i64 }, { i64*, i64 }* null, i32 1) to i64))
   %ret = bitcast i8* %0 to { i64*, i64 }*
@@ -73,7 +73,7 @@ entry:
   ret { i64*, i64 }* %ret
 }
 
-define private i64 @addXY({ i64, i64 }* %r) {
+define i64 @addXY({ i64, i64 }* %r) {
 entry:
   %0 = getelementptr { i64, i64 }, { i64, i64 }* %r, i32 0, i32 0
   %res8 = load i64, i64* %0
@@ -95,7 +95,7 @@ entry:
   ret i64 %ret
 }
 
-define private { i64, i1 }* @a() {
+define { i64, i1 }* @a() {
 entry:
   switch i1 true, label %case.0.ret [
     i1 true, label %case.0.ret

--- a/integration-tests/pass/text/text.ll
+++ b/integration-tests/pass/text/text.ll
@@ -5,7 +5,7 @@ source_filename = "<string>"
 
 declare i64 @puts(i8*)
 
-define private i8* @hello() {
+define i8* @hello() {
 entry:
   %0 = alloca i8*
   store i8* getelementptr inbounds ([21 x i8], [21 x i8]* @"$str.1", i32 0, i32 0), i8** %0

--- a/library/Amy/ANF/AST.hs
+++ b/library/Amy/ANF/AST.hs
@@ -43,6 +43,7 @@ data Module
   { moduleBindings :: ![Binding]
   , moduleExterns :: ![Extern]
   , moduleTypeDeclarations :: ![TypeDeclaration]
+  , moduleExternTypes :: ![Type]
   , moduleTextPointers :: ![TextPointer]
   , moduleClosureWrappers :: ![ClosureWrapper]
   } deriving (Show, Eq)

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Amy.ANF.Convert
   ( normalizeModule
@@ -79,7 +79,7 @@ convertDataConDefinition (C.DataConDefinition (Located _ conName) mTyArg) = do
 
 convertDataCon :: DataConName -> ANFConvert ANF.DataCon
 convertDataCon con = do
-  DataConInfo{..} <- getDataConInfo con
+  DataConInfo{dataConInfoANFType, dataConInfoConstructorIndex} <- getDataConInfo con
   pure
     ANF.DataCon
     { ANF.dataConName = con

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -47,16 +47,18 @@ normalizeModule (C.Module bindingGroups externs typeDeclarations) env =
     -- Compute new environment
     moduleEnv =
       emptyEnvironment
-      { environmentANFTypeReps = allTypeReps
+      { environmentANFTypeReps = typeRepMap
       , environmentANFFunctionTypes = Map.fromList anfFuncTys
       }
 
-  in runANFConvert (env `mergeEnvironments` moduleEnv) $ do
+  in runANFConvert env moduleEnv $ do
     typeDeclarations' <- traverse convertTypeDeclaration typeDeclarations
     bindings' <- traverse (normalizeBinding (Just "res")) bindings
+    envExterns <- getExternFunctions
+    envTypes <- getExternTypes
     textPointers <- getTextPointers
     closureWrappers <- getClosureWrappers
-    let module' = ANF.Module bindings' externs' typeDeclarations' textPointers closureWrappers
+    let module' = ANF.Module bindings' (externs' ++ envExterns) typeDeclarations' envTypes textPointers closureWrappers
     pure (module', moduleEnv)
 
 convertTypeDeclaration :: C.TypeDeclaration -> ANFConvert ANF.TypeDeclaration

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -48,7 +48,7 @@ normalizeModule (C.Module bindingGroups externs typeDeclarations) env =
     env' =
       env
       { environmentANFTypeReps = allTypeReps
-      , environmentFunctionTypes = Map.fromList anfFuncTys
+      , environmentANFFunctionTypes = Map.fromList anfFuncTys
       }
 
   in runANFConvert env' $ do

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -31,6 +31,7 @@ normalizeModule (C.Module bindingGroups externs typeDeclarations) env =
       $ (\t -> (locatedValue . C.tyConDefinitionName . C.typeDeclarationTypeName $ t, typeRep t))
       <$> typeDeclarations
     allTypeReps = environmentANFTypeReps env <> typeRepMap
+    mkANFTy = convertANFType allTypeReps
 
     -- Convert externs
     convertExtern (C.Extern name ty) =
@@ -39,7 +40,6 @@ normalizeModule (C.Module bindingGroups externs typeDeclarations) env =
     externs' = convertExtern <$> externs
 
     -- Record function types
-    mkANFTy = convertANFType allTypeReps
     bindingTys = (\b -> (C.bindingName b, (mkANFTy . C.typedType <$> C.bindingArgs b, mkANFTy $ C.bindingReturnType b))) <$> bindings
     externTys = (\(ANF.Extern name argTys retTy) -> (name, (argTys, retTy))) <$> externs'
     anfFuncTys = bindingTys ++ externTys

--- a/library/Amy/ANF/Convert.hs
+++ b/library/Amy/ANF/Convert.hs
@@ -47,7 +47,7 @@ convertExtern (C.Extern name ty) = do
 
 mkExternType :: C.Type -> ([C.Type], C.Type)
 mkExternType ty =
-  let tyNE = typeToNonEmpty ty
+  let tyNE = unfoldTyFun ty
   in (NE.init tyNE, NE.last tyNE)
 
 convertTypeDeclaration :: C.TypeDeclaration -> ANFConvert ANF.TypeDeclaration
@@ -76,7 +76,7 @@ convertDataCon con = do
     }
 
 convertType :: C.Type -> ANFConvert ANF.Type
-convertType ty = go (typeToNonEmpty ty)
+convertType ty = go (unfoldTyFun ty)
  where
   go :: NonEmpty C.Type -> ANFConvert ANF.Type
   go (ty' :| []) =
@@ -101,10 +101,6 @@ mkRecordType rows = do
     ty' <- convertType ty
     pure (label, ty')
   pure $ RecordType rows'
-
-typeToNonEmpty :: C.Type -> NonEmpty C.Type
-typeToNonEmpty (t1 `C.TyFun` t2) = NE.cons t1 (typeToNonEmpty t2)
-typeToNonEmpty ty = ty :| []
 
 convertTypedIdent :: C.Typed IdentName -> ANFConvert (ANF.Typed IdentName)
 convertTypedIdent (C.Typed ty ident) = do

--- a/library/Amy/ANF/ConvertType.hs
+++ b/library/Amy/ANF/ConvertType.hs
@@ -1,0 +1,44 @@
+module Amy.ANF.ConvertType
+  ( convertANFType
+  ) where
+
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+
+import Amy.ANF.AST as ANF
+import Amy.Syntax.AST as S
+
+-- | Converts a 'S.Type' into an ANF 'ANF.Type'
+--
+-- The only trickiness here is we have to know how type constructors are
+-- represented in order to properly convert a type.
+--
+convertANFType :: Map TyConName ANF.Type -> S.Type -> ANF.Type
+convertANFType tyConReps ty = go (unfoldTyFun ty)
+ where
+  lookupTyConRep :: TyConName -> ANF.Type
+  lookupTyConRep tyCon =
+    fromMaybe (error $ "Couldn't find ANF Type for unknown TyCon " ++ show tyCon)
+    $ Map.lookup tyCon tyConReps
+  go :: NonEmpty S.Type -> ANF.Type
+  go (ty' :| []) =
+    case ty' of
+      S.TyUnknown -> error "Encountered TyUnknown in convertType"
+      S.TyCon (MaybeLocated _ con) -> lookupTyConRep con
+      S.TyVar _ -> OpaquePointerType
+      S.TyExistVar _ -> error "Found TyExistVar in Core"
+      app@S.TyApp{} ->
+        case unfoldTyApp app of
+          TyCon (MaybeLocated _ con) :| _ -> lookupTyConRep con
+          _ -> error $ "Can't convert non-TyCon TyApp yet " ++ show ty'
+      -- N.B. ANF/LLVM doesn't care about polymorphic records
+      S.TyRecord rows _ -> mkRecordType tyConReps rows
+      S.TyFun{} -> ClosureType
+      S.TyForall _ ty'' -> convertANFType tyConReps ty''
+  go _ = ClosureType
+
+mkRecordType :: Map TyConName ANF.Type -> Map (MaybeLocated RowLabel) S.Type -> ANF.Type
+mkRecordType tyConReps rows =
+  RecordType $ flip fmap (Map.toAscList rows) $ \(MaybeLocated _ label, ty) -> (label, convertANFType tyConReps ty)

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -52,11 +52,11 @@ anfConvertRead funcs typeDeclarations =
       Map.fromList
       $ (\t -> (locatedValue . C.tyConDefinitionName . C.typeDeclarationTypeName $ t, typeRep t))
       <$> allTypeDecls
-    dataConInfos = Map.fromList $ concatMap mkDataConInfo allTypeDecls
+    dataConInfos' = Map.fromList $ concatMap mkDataConInfo allTypeDecls
   in
     ANFConvertRead
     { anfConvertReadTypeReps = typeRepMap
-    , anfConvertReadDataConInfos = dataConInfos
+    , anfConvertReadDataConInfos = dataConInfos'
     , anfConvertReadFuncTypes = Map.fromList funcs
     }
 

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -83,7 +83,7 @@ convertType ty = do
     combinedTyMap = environmentANFTypeReps $ combinedEnvironment read'
     ty' = convertANFType combinedTyMap ty
 
-  -- Figure out any external types
+  -- Record any types from outside the current module
   let
     tyCons = typeTyCons ty
     externalTyCons = tyCons `Set.difference` moduleTyCons read'
@@ -112,14 +112,14 @@ getKnownFuncType :: IdentName -> ANFConvert (Maybe ([ANF.Type], ANF.Type))
 getKnownFuncType ident = do
   read' <- ask
 
-  -- Look up known type from current module
+  -- Look up known function type from current module
   let
     moduleFuncs = environmentANFFunctionTypes $ moduleEnvironment read'
     mFunc = Map.lookup ident moduleFuncs
   case mFunc of
     Just f -> pure (Just f)
     Nothing -> do
-      -- Look up known type from external module
+      -- Look up known function type from external module
       let
         combinedFuncs = environmentANFFunctionTypes $ combinedEnvironment read'
         mExternalFunc = Map.lookup ident combinedFuncs

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -70,7 +70,7 @@ getDataConInfo con = fromMaybe err . Map.lookup con <$> asks environmentDataConI
   where
    err = error $ "Couldn't find TypeCompilationMethod of TyConDefinition " ++ show con
 
-getKnownFuncType :: IdentName -> ANFConvert (Maybe ([C.Type], C.Type))
+getKnownFuncType :: IdentName -> ANFConvert (Maybe ([ANF.Type], ANF.Type))
 getKnownFuncType ident = Map.lookup ident <$> asks environmentFunctionTypes
 
 makeTextPointer :: Text -> ANFConvert ANF.TextPointer

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -71,7 +71,7 @@ getDataConInfo con = fromMaybe err . Map.lookup con <$> asks environmentDataConI
    err = error $ "Couldn't find TypeCompilationMethod of TyConDefinition " ++ show con
 
 getKnownFuncType :: IdentName -> ANFConvert (Maybe ([ANF.Type], ANF.Type))
-getKnownFuncType ident = Map.lookup ident <$> asks environmentFunctionTypes
+getKnownFuncType ident = Map.lookup ident <$> asks environmentANFFunctionTypes
 
 makeTextPointer :: Text -> ANFConvert ANF.TextPointer
 makeTextPointer text = do

--- a/library/Amy/ANF/Monad.hs
+++ b/library/Amy/ANF/Monad.hs
@@ -47,7 +47,7 @@ data ANFConvertRead
 anfConvertRead :: [(IdentName, ([C.Type], C.Type))] -> [C.TypeDeclaration] -> ANFConvertRead
 anfConvertRead funcs typeDeclarations =
   let
-    allTypeDecls = typeDeclarations ++ allPrimTypeDefinitions
+    allTypeDecls = typeDeclarations ++ (fst <$> allPrimTypeDefinitions)
     typeRepMap =
       Map.fromList
       $ (\t -> (locatedValue . C.tyConDefinitionName . C.typeDeclarationTypeName $ t, typeRep t))

--- a/library/Amy/ANF/Pretty.hs
+++ b/library/Amy/ANF/Pretty.hs
@@ -29,7 +29,7 @@ prettyFunctionType :: [Type] -> Type -> Doc ann
 prettyFunctionType args retTy = "Func" <> groupOrHang (tupled (prettyType <$> args) <+> "=>" <+> prettyType retTy)
 
 prettyModule :: Module -> Doc ann
-prettyModule (Module bindings externs typeDeclarations _ closureWrappers) =
+prettyModule (Module bindings externs typeDeclarations _ _ closureWrappers) =
   vcatTwoHardLines
   $ (prettyExtern' <$> externs)
   ++ (prettyTypeDeclaration' <$> typeDeclarations)

--- a/library/Amy/ANF/TypeRep.hs
+++ b/library/Amy/ANF/TypeRep.hs
@@ -10,7 +10,7 @@ import Data.Text (Text)
 import GHC.Word (Word32)
 
 import Amy.ANF.AST as ANF
-import Amy.Core.AST as C
+import Amy.Syntax.AST as S
 
 -- | Describes how an Amy type is represented in LLVM.
 data TypeRep
@@ -22,14 +22,14 @@ data TypeRep
   deriving (Show, Eq, Ord)
 
 -- | Decide how we are going to compile a type declaration.
-typeRep :: C.TypeDeclaration -> ANF.Type
-typeRep (C.TypeDeclaration tyName constructors) =
+typeRep :: S.TypeDeclaration -> ANF.Type
+typeRep (S.TypeDeclaration tyName constructors) =
   case maybePrimitiveType tyName of
     Just prim -> prim
     Nothing ->
       -- Check if we can do an enum. This is when all constructors have no
       -- arguments.
-      if all (isNothing . C.dataConDefinitionArgument) constructors
+      if all (isNothing . S.dataConDefinitionArgument) constructors
       then EnumType wordSize
       -- Can't do an enum. We'll have to use tagged pairs.
       else TaggedUnionType (locatedValue $ tyConDefinitionName tyName) wordSize
@@ -41,8 +41,8 @@ typeRep (C.TypeDeclaration tyName constructors) =
       | length constructors < (2 :: Int) ^ (8 :: Int) -> 8
       | otherwise -> 32
 
-maybePrimitiveType :: C.TyConDefinition -> Maybe ANF.Type
-maybePrimitiveType (C.TyConDefinition (Located _ name) _)
+maybePrimitiveType :: S.TyConDefinition -> Maybe ANF.Type
+maybePrimitiveType (S.TyConDefinition (Located _ name) _)
   -- TODO: Something more robust here besides text name matching.
   | name == "Int" = Just PrimIntType
   | name == "Double" = Just PrimDoubleType

--- a/library/Amy/Codegen/Pure.hs
+++ b/library/Amy/Codegen/Pure.hs
@@ -104,10 +104,6 @@ codegenTopLevelBinding binding = do
     , parameters = (params, False)
     , LLVM.returnType = returnType'
     , basicBlocks = blocks
-    , linkage =
-        if ANF.bindingName binding == "main"
-          then L.External
-          else L.Private
     }
 
 codegenExpr :: ANF.Expr -> CodeGen [BasicBlock]

--- a/library/Amy/Compile.hs
+++ b/library/Amy/Compile.hs
@@ -98,9 +98,9 @@ linkModules depModules module' rtsLL = do
 
   -- Optimize LLVM
   -- TODO: This breaks some examples
-  -- let optLL = dropExtension filePath ++ "-rts-opt.ll"
-  -- opt <- lift $ optimizeLLVM linkedLL
-  -- lift $ BS8.writeFile optLL opt
+  -- let optLL = dropExtension moduleFile ++ "-rts-opt.ll"
+  -- opt <- optimizeLLVM linkedLL
+  -- BS8.writeFile optLL opt
 
   -- Compile with clang
   let exeFile = takeDirectory moduleFile </> "a.out"

--- a/library/Amy/Compile.hs
+++ b/library/Amy/Compile.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Amy.Compile
+  ( compileModule
+  , DumpFlags(..)
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.Except
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Char8 as BS8
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text.Lazy.IO as TL
+import LLVM.Pretty (ppllvm)
+import System.Environment (lookupEnv)
+import System.FilePath.Posix ((</>), dropExtension, replaceExtension, takeDirectory)
+import System.Process (callProcess)
+import Text.Megaparsec
+
+import Amy.ANF as ANF
+import Amy.Codegen
+import Amy.Core as C
+import Amy.Environment
+import Amy.Errors
+import Amy.Syntax as S
+import Amy.TypeCheck as TC
+
+compileModule
+  :: FilePath
+     -- ^ Original module file path
+  -> DumpFlags
+     -- ^ Flags to control intermediate output
+  -> Text
+     -- ^ Module source code
+  -> IO (Either [String] ())
+     -- ^ Return any possible errors
+compileModule filePath DumpFlags{..} input = runExceptT $ do
+  -- Parse
+  tokens' <- liftEither $ first ((:[]) . parseErrorPretty) $ lexer filePath input
+  parsed <- liftEither $ first ((:[]) . parseErrorPretty) $ parse (runAmyParser parseModule) filePath tokens'
+  when dfDumpParsed $
+    lift $ writeFile (filePath `replaceExtension` ".amy-parsed") (show $ S.prettyModule parsed)
+
+  -- Type checking
+  (typeChecked, typeCheckedEnv) <- liftEither $ first ((:[]) . showError) $ TC.inferModule primEnvironment parsed
+  when dfDumpTypeChecked $
+    lift $ writeFile (filePath `replaceExtension` ".amy-typechecked") (show $ S.prettyModule typeChecked)
+
+  -- Desugar to Core
+  let
+    coreEnv = mergeEnvironments primEnvironment typeCheckedEnv
+    core = desugarModule coreEnv typeChecked
+  when dfDumpCore $
+    lift $ writeFile (filePath `replaceExtension` ".amy-core") (show $ C.prettyModule core)
+
+  -- Prepare for ANF
+  let lifted = lambdaLifting core
+  when dfDumpCoreLifted $
+    lift $ writeFile (filePath `replaceExtension` ".amy-core-lifted") (show $ C.prettyModule lifted)
+
+  -- Normalize to ANF
+  let
+    anfEnv = coreEnv
+    (anf, _) = normalizeModule lifted anfEnv
+  when dfDumpANF $
+    lift $ writeFile (filePath `replaceExtension` ".amy-anf") (show $ ANF.prettyModule anf)
+
+  -- Codegen to pure LLVM
+  let llvmAST = codegenModule anf
+  when dfDumpLLVMPretty $
+    lift $ TL.writeFile (filePath `replaceExtension` ".ll-pretty") (ppllvm llvmAST)
+
+  -- Generate LLVM IR using C++ API
+  let llvmFile = filePath `replaceExtension` ".ll"
+  llvm <- lift $ generateLLVMIR llvmAST
+  lift $ BS8.writeFile llvmFile llvm
+
+  -- Link RTS
+  let linkedLL = dropExtension filePath ++ "-rts-linked.ll"
+  rtsLL <- fromMaybe "rts/rts.ll" <$> lift (lookupEnv "RTS_LL_LOCATION")
+  linked <- lift $ linkRTS rtsLL llvmFile
+  lift $ BS8.writeFile linkedLL linked
+
+  -- Optimize LLVM
+  -- TODO: This breaks some examples
+  -- let optLL = dropExtension filePath ++ "-rts-opt.ll"
+  -- opt <- lift $ optimizeLLVM linkedLL
+  -- lift $ BS8.writeFile optLL opt
+
+  -- Compile with clang
+  let exeFile = takeDirectory filePath </> "a.out"
+  lift $ callProcess "clang" ["-lgc", "-o", exeFile, linkedLL]
+
+data DumpFlags
+  = DumpFlags
+  { dfDumpParsed :: !Bool
+  , dfDumpTypeChecked :: !Bool
+  , dfDumpCore :: !Bool
+  , dfDumpCoreLifted :: !Bool
+  , dfDumpANF :: !Bool
+  , dfDumpLLVMPretty :: !Bool
+  } deriving (Show, Eq)

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -18,11 +18,12 @@ import Amy.Prim
 import Amy.Syntax.AST as S
 
 desugarModule :: Environment -> S.Module -> C.Module
-desugarModule env (S.Module _ typeDeclarations externs bindings) = do
-  let typeDeclarations' = desugarTypeDeclaration <$> typeDeclarations
-  runDesugar env typeDeclarations' $ do
+desugarModule env (S.Module _ typeDeclarations externs bindings) =
+  runDesugar env $ do
+    let
+      typeDeclarations' = desugarTypeDeclaration <$> typeDeclarations
+      externs' = desugarExtern <$> externs
     bindings' <- traverse (traverse desugarBinding) bindings
-    let externs' = desugarExtern <$> externs
     pure $ C.Module bindings' externs' typeDeclarations'
 
 desugarExtern :: S.Extern -> C.Extern

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -13,13 +13,14 @@ import Data.Maybe (maybeToList)
 import Amy.Core.AST as C
 import Amy.Core.Monad
 import Amy.Core.PatternCompiler as PC
+import Amy.Environment
 import Amy.Prim
 import Amy.Syntax.AST as S
 
-desugarModule :: S.Module -> C.Module
-desugarModule (S.Module _ typeDeclarations externs bindings) = do
+desugarModule :: Environment -> S.Module -> C.Module
+desugarModule env (S.Module _ typeDeclarations externs bindings) = do
   let typeDeclarations' = desugarTypeDeclaration <$> typeDeclarations
-  runDesugar typeDeclarations' $ do
+  runDesugar env typeDeclarations' $ do
     bindings' <- traverse (traverse desugarBinding) bindings
     let externs' = desugarExtern <$> externs
     pure $ C.Module bindings' externs' typeDeclarations'

--- a/library/Amy/Core/Desugar.hs
+++ b/library/Amy/Core/Desugar.hs
@@ -135,7 +135,7 @@ convertPattern :: S.Pattern -> Desugar PC.InputPattern
 convertPattern (S.PLit (Located _ lit)) = pure $ PC.PCon (PC.ConLit lit) []
 convertPattern (S.PVar ident) = pure $ PC.PVar $ desugarTypedIdent (locatedValue <$> ident)
 convertPattern (S.PCons (S.PatCons (Located _ con) mArg _)) = do
-  (tyDecl, _) <- lookupDataConType con
+  tyDecl <- lookupDataConType con
   argPats <- traverse convertPattern $ maybeToList mArg
   let
     argTys = maybeToList $ desugarType . patternType <$> mArg
@@ -159,7 +159,7 @@ restoreClause (PC.Clause (PC.ConLit lit) [] caseExpr) =
 restoreClause clause@(PC.Clause (PC.ConLit _) _ _) =
   error $ "Encountered literal clause with arguments! " ++ show clause
 restoreClause (PC.Clause (PC.Con con _ _) args caseExpr) = do
-  (tyDecl, _) <- lookupDataConType con
+  tyDecl <- lookupDataConType con
   let
     patTy = TyCon $ fromLocated $ tyConDefinitionName $ typeDeclarationTypeName tyDecl
     arg =

--- a/library/Amy/Core/Monad.hs
+++ b/library/Amy/Core/Monad.hs
@@ -10,7 +10,6 @@ module Amy.Core.Monad
 
 import Control.Monad.Reader
 import Control.Monad.State.Strict
-import Data.Bifunctor (first)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
@@ -21,16 +20,8 @@ import Amy.Environment
 newtype Desugar a = Desugar (ReaderT Environment (State Int) a)
   deriving (Functor, Applicative, Monad, MonadReader Environment, MonadState Int)
 
-runDesugar :: Environment -> [TypeDeclaration] -> Desugar a -> a
-runDesugar env decls (Desugar action) = evalState (runReaderT action env') 0
- where
-  -- TODO: Compute all DataConInfos for a module once and use in type checking,
-  -- Core, ANF, etc.
-  declInfos = Map.fromList $ first locatedValue <$> concatMap dataConInfos decls
-  env' =
-    env
-    { environmentDataConInfos = environmentDataConInfos env <> declInfos
-    }
+runDesugar :: Environment -> Desugar a -> a
+runDesugar env (Desugar action) = evalState (runReaderT action env) 0
 
 freshId :: Desugar Int
 freshId = do

--- a/library/Amy/Core/Monad.hs
+++ b/library/Amy/Core/Monad.hs
@@ -24,7 +24,7 @@ newtype Desugar a = Desugar (ReaderT (Map DataConName (TypeDeclaration, DataConD
 runDesugar :: [TypeDeclaration] -> Desugar a -> a
 runDesugar decls (Desugar action) = evalState (runReaderT action dataConMap) 0
  where
-  allTypeDecls = decls ++ allPrimTypeDefinitions
+  allTypeDecls = decls ++ (fst <$> allPrimTypeDefinitions)
   dataConMap = Map.fromList $ concatMap mkDataConTypes allTypeDecls
 
 freshId :: Desugar Int

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -3,12 +3,18 @@ module Amy.Environment
   , emptyEnvironment
   , mergeEnvironments
   , primEnvironment
+  , DataConInfo(..)
+  , dataConInfos
   ) where
 
 import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (maybeToList)
 
+import qualified Amy.ANF.AST as ANF
+import Amy.ANF.TypeRep
 import Amy.Kind
 import Amy.Names
 import Amy.Prim
@@ -19,6 +25,7 @@ data Environment
   { environmentIdentTypes :: !(Map IdentName Type)
   , environmentDataConInfos :: !(Map DataConName DataConInfo)
   , environmentTyConKinds :: !(Map TyConName Kind)
+  , environmentANFTypeReps :: !(Map TyConName ANF.Type)
   } deriving (Show, Eq)
 
 emptyEnvironment :: Environment
@@ -27,6 +34,7 @@ emptyEnvironment =
   { environmentIdentTypes = Map.empty
   , environmentDataConInfos = Map.empty
   , environmentTyConKinds = Map.empty
+  , environmentANFTypeReps = Map.empty
   }
 
 mergeEnvironments :: Environment -> Environment -> Environment
@@ -35,6 +43,7 @@ mergeEnvironments env1 env2 =
   { environmentIdentTypes = environmentIdentTypes env1 <> environmentIdentTypes env2
   , environmentDataConInfos = environmentDataConInfos env1 <> environmentDataConInfos env2
   , environmentTyConKinds = environmentTyConKinds env1 <> environmentTyConKinds env2
+  , environmentANFTypeReps = environmentANFTypeReps env1 <> environmentANFTypeReps env2
   }
 
 primEnvironment :: Environment
@@ -47,10 +56,35 @@ primEnvironment =
     primTyConKinds =
       (\(decl, kind) -> (locatedValue . tyConDefinitionName . typeDeclarationTypeName $ decl, kind))
       <$> allPrimTypeDefinitions
+    primTypeReps =
+      (\t -> (locatedValue . tyConDefinitionName . typeDeclarationTypeName $ t, typeRep t))
+      . fst
+      <$> allPrimTypeDefinitions
   in
     Environment
     { environmentIdentTypes = Map.fromList primFuncTypes
     , environmentDataConInfos = Map.fromList $ first locatedValue <$> primDataConInfos
     , environmentTyConKinds = Map.fromList primTyConKinds
+    , environmentANFTypeReps = Map.fromList primTypeReps
     }
 
+data DataConInfo
+  = DataConInfo
+  { dataConInfoTypeDeclaration :: !TypeDeclaration
+  , dataConInfoDataConDefinition :: !DataConDefinition
+  , dataConInfoType :: !Type
+  , dataConInfoANFType :: !ANF.Type
+  , dataConInfoConstructorIndex :: !Int
+  } deriving (Show, Eq)
+
+dataConInfos :: TypeDeclaration -> [(Located DataConName, DataConInfo)]
+dataConInfos tyDecl@(TypeDeclaration (TyConDefinition tyConName tyVars) dataConDefs) = mkDataConPair <$> zip [0..] dataConDefs
+ where
+  mkDataConPair (index, dataDef@(DataConDefinition name mTyArg)) =
+    let
+      tyVars' = TyVar . fromLocated <$> tyVars
+      tyApp = foldTyApp $ NE.fromList $ TyCon (fromLocated tyConName) : tyVars'
+      ty = foldTyFun (NE.fromList $ maybeToList mTyArg ++ [tyApp])
+      tyForall = maybe ty (\varsNE -> TyForall varsNE ty) (NE.nonEmpty $ fromLocated <$> tyVars)
+      anfTy = typeRep tyDecl
+    in (name, DataConInfo tyDecl dataDef tyForall anfTy index)

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -26,7 +26,7 @@ data Environment
   , environmentDataConInfos :: !(Map DataConName DataConInfo)
   , environmentTyConKinds :: !(Map TyConName Kind)
   , environmentANFTypeReps :: !(Map TyConName ANF.Type)
-  , environmentFunctionTypes :: !(Map IdentName ([ANF.Type], ANF.Type))
+  , environmentANFFunctionTypes :: !(Map IdentName ([ANF.Type], ANF.Type))
   } deriving (Show, Eq)
 
 emptyEnvironment :: Environment
@@ -36,7 +36,7 @@ emptyEnvironment =
   , environmentDataConInfos = Map.empty
   , environmentTyConKinds = Map.empty
   , environmentANFTypeReps = Map.empty
-  , environmentFunctionTypes = Map.empty
+  , environmentANFFunctionTypes = Map.empty
   }
 
 mergeEnvironments :: Environment -> Environment -> Environment
@@ -46,7 +46,7 @@ mergeEnvironments env1 env2 =
   , environmentDataConInfos = environmentDataConInfos env1 <> environmentDataConInfos env2
   , environmentTyConKinds = environmentTyConKinds env1 <> environmentTyConKinds env2
   , environmentANFTypeReps = environmentANFTypeReps env1 <> environmentANFTypeReps env2
-  , environmentFunctionTypes = environmentFunctionTypes env1 <> environmentFunctionTypes env2
+  , environmentANFFunctionTypes = environmentANFFunctionTypes env1 <> environmentANFFunctionTypes env2
   }
 
 primEnvironment :: Environment
@@ -69,7 +69,7 @@ primEnvironment =
     , environmentDataConInfos = Map.fromList $ first locatedValue <$> primDataConInfos
     , environmentTyConKinds = Map.fromList primTyConKinds
     , environmentANFTypeReps = Map.fromList primTypeReps
-    , environmentFunctionTypes = Map.empty
+    , environmentANFFunctionTypes = Map.empty
     }
 
 data DataConInfo

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -1,0 +1,59 @@
+module Amy.Environment
+  ( Environment(..)
+  , emptyEnvironment
+  , mergeEnvironments
+  , primEnvironment
+  ) where
+
+import Data.Bifunctor (first)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+import Amy.Kind
+import Amy.Names
+import Amy.Prim
+import Amy.Syntax.AST
+
+data Environment
+  = Environment
+  { environmentIdentTypes :: !(Map IdentName Type)
+  , environmentDataConTypes :: !(Map DataConName Type)
+  , environmentTyConKinds :: !(Map TyConName Kind)
+  } deriving (Show, Eq)
+
+emptyEnvironment :: Environment
+emptyEnvironment =
+  Environment
+  { environmentIdentTypes = Map.empty
+  , environmentDataConTypes = Map.empty
+  , environmentTyConKinds = Map.empty
+  }
+
+mergeEnvironments :: Environment -> Environment -> Environment
+mergeEnvironments env1 env2 =
+  Environment
+  { environmentIdentTypes = environmentIdentTypes env1 <> environmentIdentTypes env2
+  , environmentDataConTypes = environmentDataConTypes env1 <> environmentDataConTypes env2
+  , environmentTyConKinds = environmentTyConKinds env1 <> environmentTyConKinds env2
+  }
+
+primEnvironment :: Environment
+primEnvironment =
+  let
+    primFuncTypes = convertPrimitiveFunctionType <$> allPrimitiveFunctions
+    primDataConTypes = concatMap dataConTypes (fst <$> allPrimTypeDefinitions)
+    primTyConKinds =
+      (\(decl, kind) -> (locatedValue . tyConDefinitionName . typeDeclarationTypeName $ decl, kind))
+      <$> allPrimTypeDefinitions
+  in
+    Environment
+    { environmentIdentTypes = Map.fromList primFuncTypes
+    , environmentDataConTypes = Map.fromList $ first locatedValue <$> primDataConTypes
+    , environmentTyConKinds = Map.fromList primTyConKinds
+    }
+
+convertPrimitiveFunctionType :: PrimitiveFunction -> (IdentName, Type)
+convertPrimitiveFunctionType (PrimitiveFunction _ name ty) =
+  ( name
+  , foldTyFun $ TyCon . notLocated <$> ty
+  )

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -15,6 +15,7 @@ import Data.Maybe (maybeToList)
 
 import qualified Amy.ANF.AST as ANF
 import Amy.ANF.TypeRep
+import qualified Amy.Core.AST as C
 import Amy.Kind
 import Amy.Names
 import Amy.Prim
@@ -26,6 +27,7 @@ data Environment
   , environmentDataConInfos :: !(Map DataConName DataConInfo)
   , environmentTyConKinds :: !(Map TyConName Kind)
   , environmentANFTypeReps :: !(Map TyConName ANF.Type)
+  , environmentFunctionTypes :: !(Map IdentName ([C.Type], C.Type)) -- TODO: Use ANF.Type here
   } deriving (Show, Eq)
 
 emptyEnvironment :: Environment
@@ -35,6 +37,7 @@ emptyEnvironment =
   , environmentDataConInfos = Map.empty
   , environmentTyConKinds = Map.empty
   , environmentANFTypeReps = Map.empty
+  , environmentFunctionTypes = Map.empty
   }
 
 mergeEnvironments :: Environment -> Environment -> Environment
@@ -44,6 +47,7 @@ mergeEnvironments env1 env2 =
   , environmentDataConInfos = environmentDataConInfos env1 <> environmentDataConInfos env2
   , environmentTyConKinds = environmentTyConKinds env1 <> environmentTyConKinds env2
   , environmentANFTypeReps = environmentANFTypeReps env1 <> environmentANFTypeReps env2
+  , environmentFunctionTypes = environmentFunctionTypes env1 <> environmentFunctionTypes env2
   }
 
 primEnvironment :: Environment
@@ -66,6 +70,7 @@ primEnvironment =
     , environmentDataConInfos = Map.fromList $ first locatedValue <$> primDataConInfos
     , environmentTyConKinds = Map.fromList primTyConKinds
     , environmentANFTypeReps = Map.fromList primTypeReps
+    , environmentFunctionTypes = Map.empty
     }
 
 data DataConInfo

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -15,7 +15,6 @@ import Data.Maybe (maybeToList)
 
 import qualified Amy.ANF.AST as ANF
 import Amy.ANF.TypeRep
-import qualified Amy.Core.AST as C
 import Amy.Kind
 import Amy.Names
 import Amy.Prim
@@ -27,7 +26,7 @@ data Environment
   , environmentDataConInfos :: !(Map DataConName DataConInfo)
   , environmentTyConKinds :: !(Map TyConName Kind)
   , environmentANFTypeReps :: !(Map TyConName ANF.Type)
-  , environmentFunctionTypes :: !(Map IdentName ([C.Type], C.Type)) -- TODO: Use ANF.Type here
+  , environmentFunctionTypes :: !(Map IdentName ([ANF.Type], ANF.Type))
   } deriving (Show, Eq)
 
 emptyEnvironment :: Environment

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -40,7 +40,9 @@ mergeEnvironments env1 env2 =
 primEnvironment :: Environment
 primEnvironment =
   let
-    primFuncTypes = convertPrimitiveFunctionType <$> allPrimitiveFunctions
+    primFuncTypes =
+      (\(PrimitiveFunction _ name ty) -> (name, foldTyFun $ TyCon . notLocated <$> ty))
+      <$> allPrimitiveFunctions
     primDataConInfos = concatMap dataConInfos (fst <$> allPrimTypeDefinitions)
     primTyConKinds =
       (\(decl, kind) -> (locatedValue . tyConDefinitionName . typeDeclarationTypeName $ decl, kind))
@@ -52,8 +54,3 @@ primEnvironment =
     , environmentTyConKinds = Map.fromList primTyConKinds
     }
 
-convertPrimitiveFunctionType :: PrimitiveFunction -> (IdentName, Type)
-convertPrimitiveFunctionType (PrimitiveFunction _ name ty) =
-  ( name
-  , foldTyFun $ TyCon . notLocated <$> ty
-  )

--- a/library/Amy/Environment.hs
+++ b/library/Amy/Environment.hs
@@ -17,7 +17,7 @@ import Amy.Syntax.AST
 data Environment
   = Environment
   { environmentIdentTypes :: !(Map IdentName Type)
-  , environmentDataConTypes :: !(Map DataConName Type)
+  , environmentDataConInfos :: !(Map DataConName DataConInfo)
   , environmentTyConKinds :: !(Map TyConName Kind)
   } deriving (Show, Eq)
 
@@ -25,7 +25,7 @@ emptyEnvironment :: Environment
 emptyEnvironment =
   Environment
   { environmentIdentTypes = Map.empty
-  , environmentDataConTypes = Map.empty
+  , environmentDataConInfos = Map.empty
   , environmentTyConKinds = Map.empty
   }
 
@@ -33,7 +33,7 @@ mergeEnvironments :: Environment -> Environment -> Environment
 mergeEnvironments env1 env2 =
   Environment
   { environmentIdentTypes = environmentIdentTypes env1 <> environmentIdentTypes env2
-  , environmentDataConTypes = environmentDataConTypes env1 <> environmentDataConTypes env2
+  , environmentDataConInfos = environmentDataConInfos env1 <> environmentDataConInfos env2
   , environmentTyConKinds = environmentTyConKinds env1 <> environmentTyConKinds env2
   }
 
@@ -41,14 +41,14 @@ primEnvironment :: Environment
 primEnvironment =
   let
     primFuncTypes = convertPrimitiveFunctionType <$> allPrimitiveFunctions
-    primDataConTypes = concatMap dataConTypes (fst <$> allPrimTypeDefinitions)
+    primDataConInfos = concatMap dataConInfos (fst <$> allPrimTypeDefinitions)
     primTyConKinds =
       (\(decl, kind) -> (locatedValue . tyConDefinitionName . typeDeclarationTypeName $ decl, kind))
       <$> allPrimTypeDefinitions
   in
     Environment
     { environmentIdentTypes = Map.fromList primFuncTypes
-    , environmentDataConTypes = Map.fromList $ first locatedValue <$> primDataConTypes
+    , environmentDataConInfos = Map.fromList $ first locatedValue <$> primDataConInfos
     , environmentTyConKinds = Map.fromList primTyConKinds
     }
 

--- a/library/Amy/Prim.hs
+++ b/library/Amy/Prim.hs
@@ -38,6 +38,7 @@ import Data.Text (Text)
 import Text.Megaparsec.Pos
 
 import Amy.Literal
+import Amy.Kind
 import Amy.Names
 import Amy.Type
 import Amy.Syntax.Located
@@ -89,12 +90,12 @@ falseDataCon, trueDataCon :: DataConName
 falseDataCon = "False"
 trueDataCon = "True"
 
-allPrimTypeDefinitions :: [TypeDeclaration]
+allPrimTypeDefinitions :: [(TypeDeclaration, Kind)]
 allPrimTypeDefinitions =
-  [ intTypeDefinition
-  , doubleTypeDefinition
-  , textTypeDefinition
-  , boolTypeDefinition
+  [ (intTypeDefinition, KStar)
+  , (doubleTypeDefinition, KStar)
+  , (textTypeDefinition, KStar)
+  , (boolTypeDefinition, KStar)
   ]
 
 literalType :: Literal -> Type

--- a/library/Amy/Type.hs
+++ b/library/Amy/Type.hs
@@ -20,15 +20,12 @@ module Amy.Type
   , TypeDeclaration(..)
   , TyConDefinition(..)
   , DataConDefinition(..)
-  , DataConInfo(..)
-  , dataConInfos
   ) where
 
 import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
-import Data.Maybe (maybeToList)
 import Data.Text (pack)
 
 import Amy.Names
@@ -136,21 +133,3 @@ data DataConDefinition
   { dataConDefinitionName :: !(Located DataConName)
   , dataConDefinitionArgument :: !(Maybe Type)
   } deriving (Show, Eq)
-
-data DataConInfo
-  = DataConInfo
-  { dataConInfoTypeDeclaration :: !TypeDeclaration
-  , dataConInfoDataConDefinition :: !DataConDefinition
-  , dataConInfoType :: !Type
-  } deriving (Show, Eq)
-
-dataConInfos :: TypeDeclaration -> [(Located DataConName, DataConInfo)]
-dataConInfos tyDecl@(TypeDeclaration (TyConDefinition tyConName tyVars) dataConDefs) = mkDataConPair <$> dataConDefs
- where
-  mkDataConPair dataDef@(DataConDefinition name mTyArg) =
-    let
-      tyVars' = TyVar . fromLocated <$> tyVars
-      tyApp = foldTyApp $ NE.fromList $ TyCon (fromLocated tyConName) : tyVars'
-      ty = foldTyFun (NE.fromList $ maybeToList mTyArg ++ [tyApp])
-      tyForall = maybe ty (\varsNE -> TyForall varsNE ty) (NE.nonEmpty $ fromLocated <$> tyVars)
-    in (name, DataConInfo tyDecl dataDef tyForall)

--- a/library/Amy/TypeCheck/Monad.hs
+++ b/library/Amy/TypeCheck/Monad.hs
@@ -32,7 +32,7 @@ module Amy.TypeCheck.Monad
   , withNewLexicalScope
   , addValueTypeToScope
   , lookupValueType
-  , addDataConTypeToScope
+  , addDataConInfoToScope
   , lookupDataConType
   , addUnknownTyVarKindToScope
   , lookupTyVarKind
@@ -300,23 +300,23 @@ lookupValueType (Located span' name) = do
   mTy <- Map.lookup name <$> gets (environmentIdentTypes . stateEnvironment)
   maybe (throwError $ Error (UnknownVariable name) span') pure mTy
 
-addDataConTypeToScope :: Located DataConName -> Type -> Checker ()
-addDataConTypeToScope (Located span' name) ty =
+addDataConInfoToScope :: Located DataConName -> DataConInfo -> Checker ()
+addDataConInfoToScope (Located span' name) info =
   withSourceSpan span' $
-    insertMapDuplicateError (environmentDataConTypes . stateEnvironment) doInsert name ty DuplicateDataConstructor
+    insertMapDuplicateError (environmentDataConInfos . stateEnvironment) doInsert name info DuplicateDataConstructor
  where
   doInsert s m =
     s
     { stateEnvironment =
       (stateEnvironment s)
-      { environmentDataConTypes = m
+      { environmentDataConInfos = m
       }
     }
 
 lookupDataConType :: Located DataConName -> Checker Type
 lookupDataConType (Located span' con) = do
-  mTy <- Map.lookup con <$> gets (environmentDataConTypes . stateEnvironment)
-  maybe (throwError $ Error (UnknownDataCon con) span') pure mTy
+  mInfo <- Map.lookup con <$> gets (environmentDataConInfos . stateEnvironment)
+  maybe (throwError $ Error (UnknownDataCon con) span') (pure . dataConInfoType) mInfo
 
 addUnknownTyVarKindToScope :: TyVarName -> Checker Int
 addUnknownTyVarKindToScope name = do

--- a/library/Amy/TypeCheck/TypeCheck.hs
+++ b/library/Amy/TypeCheck/TypeCheck.hs
@@ -36,9 +36,8 @@ inferModule :: Environment -> Module -> Either Error Module
 inferModule env (Module filePath typeDeclarations externs bindings) =
   runChecker env filePath $ do
     -- Add data constructor types to scope
-    let
-      dataConstructorTypes = concatMap dataConTypes typeDeclarations
-    for_ dataConstructorTypes $ uncurry addDataConTypeToScope
+    let dataConstructorInfos = concatMap dataConInfos typeDeclarations
+    for_ dataConstructorInfos $ uncurry addDataConInfoToScope
 
     -- Infer type declaration kinds and add to scope
     for_ typeDeclarations $ \decl@(TypeDeclaration (TyConDefinition tyCon _) _) -> do

--- a/package.yaml
+++ b/package.yaml
@@ -8,13 +8,16 @@ library:
     - base
     - bytestring
     - containers
+    - filepath
     - groom
     - llvm-hs
+    - llvm-hs-pretty
     - llvm-hs-pure
     - megaparsec
     - mtl
     - parser-combinators
     - prettyprinter
+    - process
     - scientific
     - text
     - transformers
@@ -41,11 +44,8 @@ executables:
       - amy
       - base
       - bytestring
-      - filepath
       - haskeline
-      - llvm-hs-pretty
       - megaparsec
       - mtl
       - optparse-applicative
-      - process
       - text

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,2 +1,1 @@
 prelude.ll
-prelude.amy-*

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,0 +1,1 @@
+prelude.ll

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,1 +1,2 @@
 prelude.ll
+prelude.amy-*

--- a/stdlib/prelude.amy
+++ b/stdlib/prelude.amy
@@ -1,0 +1,13 @@
+Maybe a
+  = Nothing
+  | Just a
+
+Either a b
+  = Left a
+  | Right b
+
+maybe :: forall a b. b -> (a -> b) -> Maybe a -> b
+maybe default f mValue =
+  case mValue of
+    Nothing -> default
+    Just a -> f a

--- a/stdlib/prelude.amy
+++ b/stdlib/prelude.amy
@@ -11,3 +11,9 @@ maybe default f mValue =
   case mValue of
     Nothing -> default
     Just a -> f a
+
+id :: forall a. a -> a
+id x = x
+
+const :: forall a b. a -> b -> a
+const x y = x

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -35,7 +35,7 @@ match'
   :: [Typed IdentName]
   -> [Equation]
   -> CaseExpr
-match' vars eqs = runDesugar emptyEnvironment [] $ match vars eqs
+match' vars eqs = runDesugar emptyEnvironment $ match vars eqs
 
 boolTy :: Type
 boolTy = TyCon (notLocated "Bool")

--- a/tests/Amy/Core/PatternCompilerSpec.hs
+++ b/tests/Amy/Core/PatternCompilerSpec.hs
@@ -11,6 +11,7 @@ import Test.Hspec
 import Amy.Core.AST
 import Amy.Core.Monad
 import Amy.Core.PatternCompiler
+import Amy.Environment
 
 -- Utils
 mkId :: Int -> Typed IdentName
@@ -34,7 +35,7 @@ match'
   :: [Typed IdentName]
   -> [Equation]
   -> CaseExpr
-match' vars eqs = runDesugar [] $ match vars eqs
+match' vars eqs = runDesugar emptyEnvironment [] $ match vars eqs
 
 boolTy :: Type
 boolTy = TyCon (notLocated "Bool")


### PR DESCRIPTION
This PR adds the most rudimentary of module systems and linking. It adds a `prelude.amy` module with a few type and function definitions. Then, any modules we compile automatically have these prelude definitions in scope.

In order to accomplish module compilation like this, I've also added an `Environment` that contains a summary of what is in a module (mostly type definitions and types). That way we can use other module definitions in type checking, ANF conversion, and LLVM code generation without their definitions being present.